### PR TITLE
Unify editors and add tabs

### DIFF
--- a/Editor/Editor/Editors/ImageEditor.cpp
+++ b/Editor/Editor/Editors/ImageEditor.cpp
@@ -140,8 +140,8 @@ void C_ImageEditor::OnHide()
 	const bool anyModified = std::any_of(m_TabbedView.m_Tabs.begin(), m_TabbedView.m_Tabs.end(), [](const S_ImageTab& t) { return t.m_bModified; });
 	if (anyModified)
 	{
-		m_bCloseRequested = true;
-		return; // stay visible — DrawComponents will process tabs one by one
+		m_TabbedView.RequestEditorClose();
+		return;
 	}
 	GUI::C_Window::OnHide();
 }
@@ -398,52 +398,10 @@ void C_ImageEditor::DrawComponents() const
 		[this](S_ImageTab& tab) { const_cast<C_ImageEditor*>(this)->SaveTab(tab); },
 		[this](S_ImageTab& tab) { DestroyTabResources(tab); });
 
-	if (m_bCloseRequested)
-	{
-		for (unsigned int i = 0; i < m_TabbedView.m_Tabs.size(); ++i)
-		{
-			auto& tab = m_TabbedView.m_Tabs[i];
-			if (!tab.m_bModified)
-				continue;
-
-			const std::string popupId = std::string("Save changes?##EditorClose") + std::to_string(i);
-			if (!ImGui::IsPopupOpen(popupId.c_str()))
-				ImGui::OpenPopup(popupId.c_str());
-
-			if (ImGui::BeginPopupModal(popupId.c_str(), nullptr, ImGuiWindowFlags_AlwaysAutoResize))
-			{
-				ImGui::Text("Save changes to \"%s\"?", tab.m_TabLabel.c_str());
-				ImGui::Separator();
-				if (ImGui::Button("Save", ImVec2(100, 0)))
-				{
-					const_cast<C_ImageEditor*>(this)->SaveTab(tab);
-					ImGui::CloseCurrentPopup();
-				}
-				ImGui::SameLine();
-				if (ImGui::Button("Discard", ImVec2(100, 0)))
-				{
-					tab.m_bModified = false;
-					ImGui::CloseCurrentPopup();
-				}
-				ImGui::SameLine();
-				if (ImGui::Button("Cancel", ImVec2(100, 0)))
-				{
-					m_bCloseRequested = false;
-					ImGui::CloseCurrentPopup();
-				}
-				ImGui::EndPopup();
-			}
-			break; // one at a time
-		}
-
-		// All tabs resolved — proceed with actual close
-		const bool allClean = std::none_of(m_TabbedView.m_Tabs.begin(), m_TabbedView.m_Tabs.end(), [](const S_ImageTab& t) { return t.m_bModified; });
-		if (allClean)
-		{
-			m_bCloseRequested = false;
-			const_cast<C_ImageEditor*>(this)->GUI::C_Window::OnHide();
-		}
-	}
+	m_TabbedView.DrawEditorCloseModals(
+		"##ImageClose",
+		[this](S_ImageTab& tab) { const_cast<C_ImageEditor*>(this)->SaveTab(tab); },
+		[this] { const_cast<C_ImageEditor*>(this)->GUI::C_Window::OnHide(); });
 }
 
 //=================================================================================

--- a/Editor/Editor/Editors/ImageEditor.cpp
+++ b/Editor/Editor/Editors/ImageEditor.cpp
@@ -135,6 +135,18 @@ C_ImageEditor::~C_ImageEditor()
 }
 
 //=================================================================================
+void C_ImageEditor::OnHide()
+{
+	const bool anyModified = std::any_of(m_TabbedView.m_Tabs.begin(), m_TabbedView.m_Tabs.end(), [](const S_ImageTab& t) { return t.m_bModified; });
+	if (anyModified)
+	{
+		m_bCloseRequested = true;
+		return; // stay visible — DrawComponents will process tabs one by one
+	}
+	GUI::C_Window::OnHide();
+}
+
+//=================================================================================
 C_ImageEditor::S_ImageTab& C_ImageEditor::ActiveTab()
 {
 	return m_TabbedView.ActiveTab();
@@ -383,7 +395,55 @@ void C_ImageEditor::DrawComponents() const
 	m_TabbedView.Draw(
 		"##ImageTabs",
 		[this](S_ImageTab& tab) { DrawTabContent(tab); },
+		[this](S_ImageTab& tab) { SaveTab(tab); },
 		[this](S_ImageTab& tab) { DestroyTabResources(tab); });
+
+	if (m_bCloseRequested)
+	{
+		for (unsigned int i = 0; i < m_TabbedView.m_Tabs.size(); ++i)
+		{
+			auto& tab = m_TabbedView.m_Tabs[i];
+			if (!tab.m_bModified)
+				continue;
+
+			const std::string popupId = std::string("Save changes?##EditorClose") + std::to_string(i);
+			if (!ImGui::IsPopupOpen(popupId.c_str()))
+				ImGui::OpenPopup(popupId.c_str());
+
+			if (ImGui::BeginPopupModal(popupId.c_str(), nullptr, ImGuiWindowFlags_AlwaysAutoResize))
+			{
+				ImGui::Text("Save changes to \"%s\"?", tab.m_TabLabel.c_str());
+				ImGui::Separator();
+				if (ImGui::Button("Save", ImVec2(100, 0)))
+				{
+					SaveTab(tab);
+					ImGui::CloseCurrentPopup();
+				}
+				ImGui::SameLine();
+				if (ImGui::Button("Discard", ImVec2(100, 0)))
+				{
+					tab.m_bModified = false;
+					ImGui::CloseCurrentPopup();
+				}
+				ImGui::SameLine();
+				if (ImGui::Button("Cancel", ImVec2(100, 0)))
+				{
+					m_bCloseRequested = false;
+					ImGui::CloseCurrentPopup();
+				}
+				ImGui::EndPopup();
+			}
+			break; // one at a time
+		}
+
+		// All tabs resolved — proceed with actual close
+		const bool allClean = std::none_of(m_TabbedView.m_Tabs.begin(), m_TabbedView.m_Tabs.end(), [](const S_ImageTab& t) { return t.m_bModified; });
+		if (allClean)
+		{
+			m_bCloseRequested = false;
+			GUI::C_Window::OnHide();
+		}
+	}
 }
 
 //=================================================================================

--- a/Editor/Editor/Editors/ImageEditor.cpp
+++ b/Editor/Editor/Editors/ImageEditor.cpp
@@ -395,7 +395,7 @@ void C_ImageEditor::DrawComponents() const
 	m_TabbedView.Draw(
 		"##ImageTabs",
 		[this](S_ImageTab& tab) { DrawTabContent(tab); },
-		[this](S_ImageTab& tab) { SaveTab(tab); },
+		[this](S_ImageTab& tab) { const_cast<C_ImageEditor*>(this)->SaveTab(tab); },
 		[this](S_ImageTab& tab) { DestroyTabResources(tab); });
 
 	if (m_bCloseRequested)
@@ -416,7 +416,7 @@ void C_ImageEditor::DrawComponents() const
 				ImGui::Separator();
 				if (ImGui::Button("Save", ImVec2(100, 0)))
 				{
-					SaveTab(tab);
+					const_cast<C_ImageEditor*>(this)->SaveTab(tab);
 					ImGui::CloseCurrentPopup();
 				}
 				ImGui::SameLine();
@@ -441,7 +441,7 @@ void C_ImageEditor::DrawComponents() const
 		if (allClean)
 		{
 			m_bCloseRequested = false;
-			GUI::C_Window::OnHide();
+			const_cast<C_ImageEditor*>(this)->GUI::C_Window::OnHide();
 		}
 	}
 }

--- a/Editor/Editor/Editors/ImageEditor.cpp
+++ b/Editor/Editor/Editors/ImageEditor.cpp
@@ -75,40 +75,40 @@ C_ImageEditor::C_ImageEditor(GUID guid, GUI::C_GUIManager& guiMGR, T_EventCallba
 		return true;
 	}));
 	m_FileMenu.AddMenuItem(guiMGR.CreateMenuItem<GUI::Menu::C_MenuItem>("Save", [this]() {
-		if (!m_Tabs.empty())
+		if (m_TabbedView.HasTabs())
 			SaveTab(ActiveTab());
 		return true;
 	}));
 	m_FileMenu.AddMenuItem(guiMGR.CreateMenuItem<GUI::Menu::C_MenuItem>("Save As...", [this]() {
-		if (!m_Tabs.empty())
+		if (m_TabbedView.HasTabs())
 			SaveTabAs(ActiveTab());
 		return true;
 	}));
 
 	// === Playground Menu ===
 	m_ToolsMenu.AddMenuItem(guiMGR.CreateMenuItem<GUI::Menu::C_MenuItem>("Brick", [this]() {
-		if (m_Tabs.empty())
+		if (!m_TabbedView.HasTabs())
 			return false;
 		auto& tab		 = ActiveTab();
 		tab.m_ActiveTool = std::make_unique<C_BrickGenerator>(Renderer::C_TextureView(&*tab.m_Storage));
 		return true;
 	}));
 	m_ToolsMenu.AddMenuItem(guiMGR.CreateMenuItem<GUI::Menu::C_MenuItem>("Blur", [this]() {
-		if (m_Tabs.empty())
+		if (!m_TabbedView.HasTabs())
 			return false;
 		auto& tab		 = ActiveTab();
 		tab.m_ActiveTool = std::make_unique<C_GaussianBlur>(Renderer::C_TextureView(&*tab.m_Storage));
 		return true;
 	}));
 	m_ToolsMenu.AddMenuItem(guiMGR.CreateMenuItem<GUI::Menu::C_MenuItem>("Wave", [this]() {
-		if (m_Tabs.empty())
+		if (!m_TabbedView.HasTabs())
 			return false;
 		auto& tab		 = ActiveTab();
 		tab.m_ActiveTool = std::make_unique<C_WaveGenerator>(Renderer::C_TextureView(&*tab.m_Storage));
 		return true;
 	}));
 	m_ToolsMenu.AddMenuItem(guiMGR.CreateMenuItem<GUI::Menu::C_MenuItem>("Perlin Noise", [this]() {
-		if (m_Tabs.empty())
+		if (!m_TabbedView.HasTabs())
 			return false;
 		auto& tab		 = ActiveTab();
 		tab.m_ActiveTool = std::make_unique<C_PerlinNoise>(Renderer::C_TextureView(&*tab.m_Storage));
@@ -125,7 +125,7 @@ C_ImageEditor::C_ImageEditor(GUID guid, GUI::C_GUIManager& guiMGR, T_EventCallba
 //=================================================================================
 C_ImageEditor::~C_ImageEditor()
 {
-	for (auto& tab : m_Tabs)
+	for (auto& tab : m_TabbedView.m_Tabs)
 	{
 		DestroyTabResources(tab);
 	}
@@ -137,13 +137,13 @@ C_ImageEditor::~C_ImageEditor()
 //=================================================================================
 C_ImageEditor::S_ImageTab& C_ImageEditor::ActiveTab()
 {
-	return m_Tabs[m_ActiveTabIndex];
+	return m_TabbedView.ActiveTab();
 }
 
 //=================================================================================
 const C_ImageEditor::S_ImageTab& C_ImageEditor::ActiveTab() const
 {
-	return m_Tabs[m_ActiveTabIndex];
+	return m_TabbedView.ActiveTab();
 }
 
 //=================================================================================
@@ -151,7 +151,7 @@ C_ImageEditor::S_ImageTab& C_ImageEditor::CreateTab(Core::ResourceHandle<Rendere
 {
 	auto& renderer = Core::C_Application::Get().GetActiveRenderer();
 
-	auto& tab			 = m_Tabs.emplace_back();
+	auto& tab			 = m_TabbedView.EmplaceTab();
 	tab.m_ResourceHandle = std::move(handle);
 
 	// Create per-tab GPU texture
@@ -182,14 +182,8 @@ C_ImageEditor::S_ImageTab& C_ImageEditor::CreateTab(Core::ResourceHandle<Rendere
 void C_ImageEditor::OpenImage(Core::ResourceHandle<Renderer::TextureResource> handle)
 {
 	// Deduplication: if already open, just switch focus
-	for (unsigned int i = 0; i < m_Tabs.size(); ++i)
-	{
-		if (m_Tabs[i].m_ResourceHandle == handle)
-		{
-			m_ActiveTabIndex = i;
-			return;
-		}
-	}
+	if (m_TabbedView.TrySwitchTo([&](const S_ImageTab& t) { return t.m_ResourceHandle == handle; }))
+		return;
 
 	if (handle.IsFailed())
 		return;
@@ -314,7 +308,7 @@ bool C_ImageEditor::CanDestroy() const
 {
 	// Block destruction while any tab has unsaved changes
 	// TODO: show "Save before closing?" dialog
-	return std::none_of(m_Tabs.begin(), m_Tabs.end(), [](const S_ImageTab& t) { return t.m_bModified; });
+	return std::none_of(m_TabbedView.m_Tabs.begin(), m_TabbedView.m_Tabs.end(), [](const S_ImageTab& t) { return t.m_bModified; });
 }
 
 //=================================================================================
@@ -322,7 +316,7 @@ void C_ImageEditor::Update()
 {
 	auto& renderer = Core::C_Application::Get().GetActiveRenderer();
 
-	for (auto& tab : m_Tabs)
+	for (auto& tab : m_TabbedView.m_Tabs)
 	{
 		// Poll pending resource loads (resource handle present but storage not yet copied)
 		if (tab.m_ResourceHandle && !tab.m_Storage)
@@ -380,39 +374,16 @@ void C_ImageEditor::Update()
 //=================================================================================
 void C_ImageEditor::DrawComponents() const
 {
-	if (m_Tabs.empty())
+	if (!m_TabbedView.HasTabs())
 	{
 		ImGui::TextUnformatted("No images open. Use File > New Image or File > Save As.");
 		return;
 	}
 
-	if (ImGui::BeginTabBar("##ImageTabs", ImGuiTabBarFlags_AutoSelectNewTabs))
-	{
-		for (unsigned int i = 0; i < m_Tabs.size(); ++i)
-		{
-			auto& tab = m_Tabs[i];
-
-			const std::string label = tab.m_TabLabel + (tab.m_bModified ? " *" : "") + "##tab" + std::to_string(i);
-			bool			  open	= true;
-
-			if (ImGui::BeginTabItem(label.c_str(), &open))
-			{
-				m_ActiveTabIndex = i;
-				DrawTabContent(tab);
-				ImGui::EndTabItem();
-			}
-
-			if (!open)
-			{
-				DestroyTabResources(tab);
-				m_Tabs.erase(m_Tabs.begin() + i);
-				if (m_ActiveTabIndex >= m_Tabs.size())
-					m_ActiveTabIndex = std::max(0, static_cast<int>(m_Tabs.size()) - 1);
-				--i;
-			}
-		}
-		ImGui::EndTabBar();
-	}
+	m_TabbedView.Draw(
+		"##ImageTabs",
+		[this](S_ImageTab& tab) { DrawTabContent(tab); },
+		[this](S_ImageTab& tab) { DestroyTabResources(tab); });
 }
 
 //=================================================================================

--- a/Editor/Editor/Editors/ImageEditor.h
+++ b/Editor/Editor/Editors/ImageEditor.h
@@ -8,6 +8,7 @@
 
 #include <GUI/GUIWindow.h>
 #include <GUI/ImageViewer.h>
+#include <GUI/TabbedView.h>
 
 #include <Core/EventSystem/Event.h>
 #include <Core/Resources/ResourceHandle.h>
@@ -78,8 +79,6 @@ private:
 	GUI::C_GUIManager&					m_GUIManager;
 	T_EventCallback						m_EventCallback;
 
-	// unique_ptr per tab so the vector is moveable regardless of S_ImageTab's move semantics
-	mutable std::vector<S_ImageTab> m_Tabs;
-	mutable unsigned int										 m_ActiveTabIndex = 0;
+	mutable GUI::C_TabbedView<S_ImageTab> m_TabbedView;
 };
 } // namespace GLEngine::Editor

--- a/Editor/Editor/Editors/ImageEditor.h
+++ b/Editor/Editor/Editors/ImageEditor.h
@@ -81,6 +81,5 @@ private:
 	T_EventCallback						m_EventCallback;
 
 	mutable GUI::C_TabbedView<S_ImageTab> m_TabbedView;
-	mutable bool						  m_bCloseRequested = false;
 };
 } // namespace GLEngine::Editor

--- a/Editor/Editor/Editors/ImageEditor.h
+++ b/Editor/Editor/Editors/ImageEditor.h
@@ -45,6 +45,7 @@ public:
 	bool CanDestroy() const override;
 
 protected:
+	void OnHide() override;
 	void DrawComponents() const override;
 
 private:
@@ -80,5 +81,6 @@ private:
 	T_EventCallback						m_EventCallback;
 
 	mutable GUI::C_TabbedView<S_ImageTab> m_TabbedView;
+	mutable bool						  m_bCloseRequested = false;
 };
 } // namespace GLEngine::Editor

--- a/Editor/Editor/Editors/MaterialPreview/MaterialPreviewWindow.cpp
+++ b/Editor/Editor/Editors/MaterialPreview/MaterialPreviewWindow.cpp
@@ -1,6 +1,7 @@
 #include <EditorStdafx.h>
 
 #include <Editor/Editors/MaterialPreview/MaterialPreviewWindow.h>
+#include <Editor/Editors/RayPreviewState.h>
 
 #include <Renderer/Colours.h>
 #include <Renderer/IDevice.h>
@@ -15,6 +16,7 @@
 #include <Renderer/Textures/TextureView.h>
 
 #include <GUI/GUIManager.h>
+#include <GUI/ImageViewer.h>
 #include <GUI/ResourceDialogWindow.h>
 
 #include <Physics/Primitives/Disc.h>
@@ -38,7 +40,6 @@ C_MaterialPreviewWindow::C_MaterialPreviewWindow(GUID guid, GUI::C_GUIManager& g
 	, m_FileMenu("File")
 	, m_GUIManager(guiMGR)
 {
-	// === File Menu ===
 	m_FileMenu.AddMenuItem(guiMGR.CreateMenuItem<GUI::Menu::C_MenuItem>("New material", [this]() {
 		NewMaterial();
 		return true;
@@ -62,21 +63,14 @@ C_MaterialPreviewWindow::C_MaterialPreviewWindow(GUID guid, GUI::C_GUIManager& g
 //=================================================================================
 C_MaterialPreviewWindow::~C_MaterialPreviewWindow()
 {
-	auto& rm = Core::C_Application::Get().GetActiveRenderer().GetRM();
 	for (auto& tab : m_TabbedView.m_Tabs)
-	{
-		if (!tab.m_Data)
-			continue;
-		StopTab(*tab.m_Data);
-		if (tab.m_Data->m_GPUImageHandle.IsValid())
-			rm.destoryTexture(tab.m_Data->m_GPUImageHandle);
-	}
+		if (tab.m_Data)
+			DestroyTabResources(tab);
 }
 
 //=================================================================================
 void C_MaterialPreviewWindow::OpenMaterial(Core::ResourceHandle<Renderer::MaterialResource> handle)
 {
-	// Deduplication: switch to the tab if already open
 	if (m_TabbedView.TrySwitchTo([&](const S_MaterialTab& t) {
 			return t.m_Data && t.m_Data->m_Material == handle;
 		}))
@@ -87,43 +81,10 @@ void C_MaterialPreviewWindow::OpenMaterial(Core::ResourceHandle<Renderer::Materi
 	tab.m_Data->m_Material = std::move(handle);
 	tab.m_TabLabel	   = tab.m_Data->m_Material.GetFilePath().filename().string();
 
-	CreateTabResources(*tab.m_Data);
+	CreateRayPreviewState(tab.m_Data->m_Render, s_Resolution, "materialPreview",
+						  Renderer::E_TextureFormat::RGB32f);
 	SetupScene(*tab.m_Data);
 	StartRender(*tab.m_Data);
-}
-
-//=================================================================================
-void C_MaterialPreviewWindow::CreateTabResources(S_MaterialTabData& data)
-{
-	auto& renderer = Core::C_Application::Get().GetActiveRenderer();
-
-	data.m_ImageStorage.emplace(s_Resolution.x, s_Resolution.y, 3);
-	data.m_SamplesStorage.emplace(s_Resolution.x, s_Resolution.y, 3);
-
-	data.m_GPUImageHandle = renderer.GetRM().createTexture(Renderer::TextureDescriptor{
-		.name		   = "materialPreview",
-		.width		   = s_Resolution.x,
-		.height		   = s_Resolution.y,
-		.type		   = Renderer::E_TextureType::TEXTURE_2D,
-		.format		   = Renderer::E_TextureFormat::RGB32f,
-		.m_bStreamable = false,
-	});
-	const auto samplerHandle = renderer.GetRM().createSampler(Renderer::SamplerDescriptor2D{
-		.m_FilterMin = Renderer::E_TextureFilter::Linear,
-		.m_FilterMag = Renderer::E_TextureFilter::Linear,
-		.m_WrapS	 = Renderer::E_WrapFunction::Repeat,
-		.m_WrapT	 = Renderer::E_WrapFunction::Repeat,
-		.m_WrapU	 = Renderer::E_WrapFunction::Repeat,
-	});
-	renderer.SetTextureSampler(data.m_GPUImageHandle, samplerHandle);
-
-	data.m_GUIImage.emplace(data.m_GPUImageHandle);
-	data.m_GUIImage->SetSize({s_Resolution.x, s_Resolution.y});
-
-	constexpr glm::vec4 black{0.f, 0.f, 0.f, 1.f};
-	Renderer::C_TextureView(&*data.m_ImageStorage).ClearColor(black);
-	Renderer::C_TextureView(&*data.m_SamplesStorage).ClearColor(black);
-	renderer.SetTextureData(data.m_GPUImageHandle, *data.m_ImageStorage);
 }
 
 //=================================================================================
@@ -163,7 +124,7 @@ void C_MaterialPreviewWindow::SetupScene(S_MaterialTabData& data)
 	discPrimitive->SetMaterial(data.m_Scene.AddMaterial(s_Black).get());
 	data.m_Scene.AddLight(std::make_shared<Renderer::RayTracing::C_AreaLight>(glm::vec3(1.f, 1.f, 1.f), discPrimitive));
 
-	data.m_Renderer = std::make_unique<Renderer::C_RayRenderer>(data.m_Scene);
+	data.m_Render.m_Renderer = std::make_unique<Renderer::C_RayRenderer>(data.m_Scene);
 }
 
 //=================================================================================
@@ -172,23 +133,6 @@ void C_MaterialPreviewWindow::SetupCamera()
 	m_Camera.SetupCameraView(3.f, glm::vec3(0.f), 45.f, 35.f);
 	m_Camera.SetupCameraProjection(2.f, 4.f, 1.f, 40.f);
 	m_Camera.Update();
-}
-
-//=================================================================================
-void C_MaterialPreviewWindow::UploadStorage(S_MaterialTabData& data)
-{
-	if (!data.m_Renderer)
-		return;
-
-	if (data.m_ImageLock.try_lock())
-	{
-		if (data.m_Renderer->NewResultAvailable())
-		{
-			Core::C_Application::Get().GetActiveRenderer().SetTextureData(data.m_GPUImageHandle, *data.m_ImageStorage);
-			data.m_Renderer->SetResultConsumed();
-		}
-		data.m_ImageLock.unlock();
-	}
 }
 
 //=================================================================================
@@ -201,7 +145,7 @@ void C_MaterialPreviewWindow::Update()
 		auto& data = *tab.m_Data;
 		if (data.m_RebuildPending.exchange(false))
 			RebuildAndRestart(data);
-		UploadStorage(data);
+		UploadPreviewStorage(data.m_Render);
 	}
 }
 
@@ -223,52 +167,13 @@ void C_MaterialPreviewWindow::DrawComponents() const
 		},
 		[this](S_MaterialTab& tab) { const_cast<C_MaterialPreviewWindow*>(this)->DestroyTabResources(tab); });
 
-	if (m_bCloseRequested)
-	{
-		for (unsigned int i = 0; i < m_TabbedView.m_Tabs.size(); ++i)
-		{
-			auto& tab = m_TabbedView.m_Tabs[i];
-			if (!tab.m_bModified)
-				continue;
-
-			const std::string popupId = std::string("Save changes?##MatClose") + std::to_string(i);
-			if (!ImGui::IsPopupOpen(popupId.c_str()))
-				ImGui::OpenPopup(popupId.c_str());
-
-			if (ImGui::BeginPopupModal(popupId.c_str(), nullptr, ImGuiWindowFlags_AlwaysAutoResize))
-			{
-				ImGui::Text("Save changes to \"%s\"?", tab.m_TabLabel.c_str());
-				ImGui::Separator();
-				if (ImGui::Button("Save", ImVec2(100, 0)))
-				{
-					if (tab.m_Data)
-						const_cast<C_MaterialPreviewWindow*>(this)->SaveMaterial(*tab.m_Data);
-					ImGui::CloseCurrentPopup();
-				}
-				ImGui::SameLine();
-				if (ImGui::Button("Discard", ImVec2(100, 0)))
-				{
-					tab.m_bModified = false;
-					ImGui::CloseCurrentPopup();
-				}
-				ImGui::SameLine();
-				if (ImGui::Button("Cancel", ImVec2(100, 0)))
-				{
-					m_bCloseRequested = false;
-					ImGui::CloseCurrentPopup();
-				}
-				ImGui::EndPopup();
-			}
-			break; // one at a time
-		}
-
-		const bool allClean = std::none_of(m_TabbedView.m_Tabs.begin(), m_TabbedView.m_Tabs.end(), [](const S_MaterialTab& t) { return t.m_bModified; });
-		if (allClean)
-		{
-			m_bCloseRequested = false;
-			const_cast<C_MaterialPreviewWindow*>(this)->GUI::C_Window::OnHide();
-		}
-	}
+	m_TabbedView.DrawEditorCloseModals(
+		"##MatClose",
+		[this](S_MaterialTab& tab) {
+			if (tab.m_Data)
+				const_cast<C_MaterialPreviewWindow*>(this)->SaveMaterial(*tab.m_Data);
+		},
+		[this] { const_cast<C_MaterialPreviewWindow*>(this)->GUI::C_Window::OnHide(); });
 }
 
 //=================================================================================
@@ -280,8 +185,8 @@ void C_MaterialPreviewWindow::DrawTabContent(const S_MaterialTab& tab) const
 	if (data.m_Material.IsReady() && data.m_Material.GetResource().IsModified())
 		ImGui::Text("Material modified");
 
-	if (data.m_GUIImage)
-		std::ignore = data.m_GUIImage->Draw();
+	if (data.m_Render.m_GUIImage)
+		std::ignore = data.m_Render.m_GUIImage->Draw();
 
 	// Shape selector
 	ImGui::Text("Shape:");
@@ -324,41 +229,22 @@ void C_MaterialPreviewWindow::DrawTabContent(const S_MaterialTab& tab) const
 
 	ImGui::Separator();
 
-	// Render progress
-	const int samples = data.m_NumSamples.load();
-	if (data.m_Running.load())
-	{
-		ImGui::ProgressBar(static_cast<float>(samples) / s_TargetSamples, ImVec2(-1.f, 0.f));
-		ImGui::Text("Rendering... %d / %d samples", samples, s_TargetSamples);
-	}
-	else
-	{
-		ImGui::Text("Done \xe2\x80\x94 %d samples", samples);
-		if (ImGui::Button("Re-render"))
-			self->StartRender(const_cast<S_MaterialTabData&>(data));
-	}
+	if (DrawRenderProgress(data.m_Render, s_TargetSamples))
+		self->StartRender(const_cast<S_MaterialTabData&>(data));
 }
 
 //=================================================================================
 void C_MaterialPreviewWindow::RebuildAndRestart(S_MaterialTabData& data)
 {
-	StopTab(data);
-	data.m_StopRequested.store(false);
+	StopPreviewRender(data.m_Render);
+	data.m_Render.m_StopRequested.store(false);
 
 	constexpr glm::vec4 black{0.f, 0.f, 0.f, 1.f};
-	Renderer::C_TextureView(&*data.m_ImageStorage).ClearColor(black);
-	Renderer::C_TextureView(&*data.m_SamplesStorage).ClearColor(black);
+	Renderer::C_TextureView(&*data.m_Render.m_ImageStorage).ClearColor(black);
+	Renderer::C_TextureView(&*data.m_Render.m_SamplesStorage).ClearColor(black);
 
 	SetupScene(data);
 	StartRender(data);
-}
-
-//=================================================================================
-void C_MaterialPreviewWindow::StopTab(S_MaterialTabData& data)
-{
-	data.m_StopRequested.store(true);
-	while (data.m_Running.load())
-		std::this_thread::sleep_for(std::chrono::milliseconds(5));
 }
 
 //=================================================================================
@@ -366,10 +252,7 @@ void C_MaterialPreviewWindow::DestroyTabResources(S_MaterialTab& tab)
 {
 	if (!tab.m_Data)
 		return;
-	StopTab(*tab.m_Data);
-	auto& rm = Core::C_Application::Get().GetActiveRenderer().GetRM();
-	if (tab.m_Data->m_GPUImageHandle.IsValid())
-		rm.destoryTexture(tab.m_Data->m_GPUImageHandle);
+	DestroyRayPreviewState(tab.m_Data->m_Render);
 }
 
 //=================================================================================
@@ -425,25 +308,29 @@ void C_MaterialPreviewWindow::SaveMaterialAs(S_MaterialTabData& data)
 //=================================================================================
 void C_MaterialPreviewWindow::StartRender(S_MaterialTabData& data)
 {
-	if (data.m_Running.load())
+	if (data.m_Render.m_Running.load())
 		return;
 
-	data.m_NumSamples.store(0);
-	data.m_StopRequested.store(false);
-	data.m_Running.store(true);
+	data.m_Render.m_NumSamples.store(0);
+	data.m_Render.m_StopRequested.store(false);
+	data.m_Render.m_Running.store(true);
 
 	std::thread([&data, this]() {
-		while (!data.m_StopRequested.load())
+		while (!data.m_Render.m_StopRequested.load())
 		{
-			const int samplesBefore = data.m_NumSamples.load();
+			const int samplesBefore = data.m_Render.m_NumSamples.load();
 			if (samplesBefore >= s_TargetSamples)
 				break;
 
-			data.m_Renderer->Render(m_Camera, *data.m_ImageStorage, *data.m_SamplesStorage, &data.m_ImageLock, samplesBefore,
-									Renderer::C_InterleavedLinesFactory{4});
-			data.m_NumSamples.fetch_add(1);
+			data.m_Render.m_Renderer->Render(m_Camera,
+											 *data.m_Render.m_ImageStorage,
+											 *data.m_Render.m_SamplesStorage,
+											 &data.m_Render.m_ImageLock,
+											 samplesBefore,
+											 Renderer::C_InterleavedLinesFactory{4});
+			data.m_Render.m_NumSamples.fetch_add(1);
 		}
-		data.m_Running.store(false);
+		data.m_Render.m_Running.store(false);
 	}).detach();
 }
 
@@ -452,7 +339,7 @@ void C_MaterialPreviewWindow::RequestDestroy()
 {
 	for (auto& tab : m_TabbedView.m_Tabs)
 		if (tab.m_Data)
-			tab.m_Data->m_StopRequested.store(true);
+			tab.m_Data->m_Render.m_StopRequested.store(true);
 	m_WantToBeDestroyed = true;
 }
 
@@ -462,7 +349,7 @@ void C_MaterialPreviewWindow::OnHide()
 	const bool anyModified = std::any_of(m_TabbedView.m_Tabs.begin(), m_TabbedView.m_Tabs.end(), [](const S_MaterialTab& t) { return t.m_bModified; });
 	if (anyModified)
 	{
-		m_bCloseRequested = true;
+		m_TabbedView.RequestEditorClose();
 		return;
 	}
 	GUI::C_Window::OnHide();
@@ -471,7 +358,7 @@ void C_MaterialPreviewWindow::OnHide()
 //=================================================================================
 bool C_MaterialPreviewWindow::CanDestroy() const
 {
-	return std::none_of(m_TabbedView.m_Tabs.begin(), m_TabbedView.m_Tabs.end(), [](const S_MaterialTab& t) { return t.m_Data && t.m_Data->m_Running.load(); });
+	return std::none_of(m_TabbedView.m_Tabs.begin(), m_TabbedView.m_Tabs.end(), [](const S_MaterialTab& t) { return t.m_Data && t.m_Data->m_Render.m_Running.load(); });
 }
 
 } // namespace GLEngine::Editor

--- a/Editor/Editor/Editors/MaterialPreview/MaterialPreviewWindow.cpp
+++ b/Editor/Editor/Editors/MaterialPreview/MaterialPreviewWindow.cpp
@@ -23,9 +23,6 @@
 #include <Physics/Primitives/Plane.h>
 #include <Physics/Primitives/Sphere.h>
 
-#include <Core/Application.h>
-
-#include "../../../../vendor/Assimp/code/AssetLib/M3D/m3d.h"
 #include <algorithm>
 #include <chrono>
 #include <cmath>
@@ -138,6 +135,8 @@ void C_MaterialPreviewWindow::SetupCamera()
 //=================================================================================
 void C_MaterialPreviewWindow::Update()
 {
+	if (m_WantToBeDestroyed)
+		return;
 	for (auto& tab : m_TabbedView.m_Tabs)
 	{
 		if (!tab.m_Data)

--- a/Editor/Editor/Editors/MaterialPreview/MaterialPreviewWindow.cpp
+++ b/Editor/Editor/Editors/MaterialPreview/MaterialPreviewWindow.cpp
@@ -9,8 +9,8 @@
 #include <Renderer/Materials/PBRMaterialData.h>
 #include <Renderer/Mesh/Scene.h>
 #include <Renderer/RayCasting/Geometry/PrimitiveObject.h>
-#include <Renderer/RayCasting/RayGeneration/InterleavedLinesFactory.h>
 #include <Renderer/RayCasting/Light/RayAreaLight.h>
+#include <Renderer/RayCasting/RayGeneration/InterleavedLinesFactory.h>
 #include <Renderer/Resources/ResourceManager.h>
 #include <Renderer/Textures/TextureView.h>
 
@@ -23,6 +23,7 @@
 
 #include <Core/Application.h>
 
+#include "../../../../vendor/Assimp/code/AssetLib/M3D/m3d.h"
 #include <algorithm>
 #include <chrono>
 #include <cmath>
@@ -32,12 +33,8 @@
 namespace GLEngine::Editor {
 
 //=================================================================================
-C_MaterialPreviewWindow::C_MaterialPreviewWindow(GUID guid, GUI::C_GUIManager& guiMGR, Core::ResourceHandle<Renderer::MaterialResource> material)
+C_MaterialPreviewWindow::C_MaterialPreviewWindow(GUID guid, GUI::C_GUIManager& guiMGR)
 	: GUI::C_Window(guid, "Material Preview")
-	, m_Material(std::move(material))
-	, m_ImageStorage(s_Resolution.x, s_Resolution.y, 3)
-	, m_SamplesStorage(s_Resolution.x, s_Resolution.y, 3)
-	, m_GUIImage({})
 	, m_FileMenu("File")
 	, m_GUIManager(guiMGR)
 {
@@ -47,17 +44,63 @@ C_MaterialPreviewWindow::C_MaterialPreviewWindow(GUID guid, GUI::C_GUIManager& g
 		return true;
 	}));
 	m_FileMenu.AddMenuItem(guiMGR.CreateMenuItem<GUI::Menu::C_MenuItem>("Save", [this]() {
-		SaveMaterial();
+		if (m_TabbedView.HasTabs() && m_TabbedView.ActiveTab().m_Data)
+			SaveMaterial(*m_TabbedView.ActiveTab().m_Data);
 		return true;
 	}));
 	m_FileMenu.AddMenuItem(guiMGR.CreateMenuItem<GUI::Menu::C_MenuItem>("Save As...", [this]() {
-		SaveMaterialAs();
+		if (m_TabbedView.HasTabs() && m_TabbedView.ActiveTab().m_Data)
+			SaveMaterialAs(*m_TabbedView.ActiveTab().m_Data);
 		return true;
 	}));
 
+	AddMenu(m_FileMenu);
+
+	SetupCamera();
+}
+
+//=================================================================================
+C_MaterialPreviewWindow::~C_MaterialPreviewWindow()
+{
+	auto& rm = Core::C_Application::Get().GetActiveRenderer().GetRM();
+	for (auto& tab : m_TabbedView.m_Tabs)
+	{
+		if (!tab.m_Data)
+			continue;
+		StopTab(*tab.m_Data);
+		if (tab.m_Data->m_GPUImageHandle.IsValid())
+			rm.destoryTexture(tab.m_Data->m_GPUImageHandle);
+	}
+}
+
+//=================================================================================
+void C_MaterialPreviewWindow::OpenMaterial(Core::ResourceHandle<Renderer::MaterialResource> handle)
+{
+	// Deduplication: switch to the tab if already open
+	if (m_TabbedView.TrySwitchTo([&](const S_MaterialTab& t) {
+			return t.m_Data && t.m_Data->m_Material == handle;
+		}))
+		return;
+
+	auto& tab		   = m_TabbedView.EmplaceTab();
+	tab.m_Data		   = std::make_unique<S_MaterialTabData>();
+	tab.m_Data->m_Material = std::move(handle);
+	tab.m_TabLabel	   = tab.m_Data->m_Material.GetFilePath().filename().string();
+
+	CreateTabResources(*tab.m_Data);
+	SetupScene(*tab.m_Data);
+	StartRender(*tab.m_Data);
+}
+
+//=================================================================================
+void C_MaterialPreviewWindow::CreateTabResources(S_MaterialTabData& data)
+{
 	auto& renderer = Core::C_Application::Get().GetActiveRenderer();
 
-	m_GPUImageHandle		 = renderer.GetRM().createTexture(Renderer::TextureDescriptor{
+	data.m_ImageStorage.emplace(s_Resolution.x, s_Resolution.y, 3);
+	data.m_SamplesStorage.emplace(s_Resolution.x, s_Resolution.y, 3);
+
+	data.m_GPUImageHandle = renderer.GetRM().createTexture(Renderer::TextureDescriptor{
 		.name		   = "materialPreview",
 		.width		   = s_Resolution.x,
 		.height		   = s_Resolution.y,
@@ -72,44 +115,38 @@ C_MaterialPreviewWindow::C_MaterialPreviewWindow(GUID guid, GUI::C_GUIManager& g
 		.m_WrapT	 = Renderer::E_WrapFunction::Repeat,
 		.m_WrapU	 = Renderer::E_WrapFunction::Repeat,
 	});
-	renderer.SetTextureSampler(m_GPUImageHandle, samplerHandle);
+	renderer.SetTextureSampler(data.m_GPUImageHandle, samplerHandle);
 
-	m_GUIImage = GUI::C_ImageViewer(m_GPUImageHandle);
-	m_GUIImage.SetSize({s_Resolution.x, s_Resolution.y});
+	data.m_GUIImage.emplace(data.m_GPUImageHandle);
+	data.m_GUIImage->SetSize({s_Resolution.x, s_Resolution.y});
 
 	constexpr glm::vec4 black{0.f, 0.f, 0.f, 1.f};
-	Renderer::C_TextureView(&m_ImageStorage).ClearColor(black);
-	Renderer::C_TextureView(&m_SamplesStorage).ClearColor(black);
-	renderer.SetTextureData(m_GPUImageHandle, m_ImageStorage);
-
-	SetupScene();
-	StartRender();
+	Renderer::C_TextureView(&*data.m_ImageStorage).ClearColor(black);
+	Renderer::C_TextureView(&*data.m_SamplesStorage).ClearColor(black);
+	renderer.SetTextureData(data.m_GPUImageHandle, *data.m_ImageStorage);
 }
 
 //=================================================================================
-void C_MaterialPreviewWindow::SetupScene()
+void C_MaterialPreviewWindow::SetupScene(S_MaterialTabData& data)
 {
-	m_Scene.ClearScene();
+	data.m_Scene.ClearScene();
 
-	auto&		matInterface = m_Scene.AddMaterial(m_Material);
-	const auto* matPBR		 = dynamic_cast<const Renderer::C_PBRMaterialData*>(m_Material.GetResource().GetMaterialData());
+	if (!data.m_Material.IsReady())
+		return;
+
+	auto&		matInterface = data.m_Scene.AddMaterial(data.m_Material);
+	const auto* matPBR		 = dynamic_cast<const Renderer::C_PBRMaterialData*>(data.m_Material.GetResource().GetMaterialData());
 
 	std::shared_ptr<Renderer::I_RayGeometryObject> prim;
-
-	if (m_PreviewShape == E_PreviewShape::Sphere)
-	{
+	if (data.m_PreviewShape == E_PreviewShape::Sphere)
 		prim = std::make_shared<Renderer::C_Primitive<Physics::Primitives::S_Sphere>>(Physics::Primitives::S_Sphere{glm::vec3(0.f), 1.f});
-	}
-	else // Plane
-	{
+	else
 		prim = std::make_shared<Renderer::C_Primitive<Physics::Primitives::S_Plane>>(Physics::Primitives::S_Plane{glm::vec3(0.f, 1.f, 0.f), 0.f});
-	}
+
 	prim->SetMaterial(matInterface.get());
 	if (matPBR)
-	{
 		prim->SetAlphaMask(matPBR->GetColorMapRes());
-	}
-	m_Scene.AddObject(std::move(prim));
+	data.m_Scene.AddObject(std::move(prim));
 
 	static const Renderer::MeshData::Material s_Black{.ambient			  = glm::vec4{},
 													  .diffuse			  = glm::vec4{Colours::black, 0.f},
@@ -123,82 +160,142 @@ void C_MaterialPreviewWindow::SetupScene()
 	auto			disc		= Physics::Primitives::S_Disc(lightNormal, glm::vec3(0.f, 4.f, 0.f), 2.f);
 	disc.plane.twoSided			= false;
 	auto discPrimitive			= std::make_shared<Renderer::C_Primitive<Physics::Primitives::S_Disc>>(disc);
-	discPrimitive->SetMaterial(m_Scene.AddMaterial(s_Black).get());
-	m_Scene.AddLight(std::make_shared<Renderer::RayTracing::C_AreaLight>(glm::vec3(1.f, 1.f, 1.f), discPrimitive));
+	discPrimitive->SetMaterial(data.m_Scene.AddMaterial(s_Black).get());
+	data.m_Scene.AddLight(std::make_shared<Renderer::RayTracing::C_AreaLight>(glm::vec3(1.f, 1.f, 1.f), discPrimitive));
 
-	SetupCamera();
-
-	m_Renderer = std::make_unique<Renderer::C_RayRenderer>(m_Scene);
+	data.m_Renderer = std::make_unique<Renderer::C_RayRenderer>(data.m_Scene);
 }
 
 //=================================================================================
 void C_MaterialPreviewWindow::SetupCamera()
 {
-	// Unit sphere/plane at origin — camera 3 units away
 	m_Camera.SetupCameraView(3.f, glm::vec3(0.f), 45.f, 35.f);
 	m_Camera.SetupCameraProjection(2.f, 4.f, 1.f, 40.f);
 	m_Camera.Update();
 }
 
 //=================================================================================
-void C_MaterialPreviewWindow::UploadStorage()
+void C_MaterialPreviewWindow::UploadStorage(S_MaterialTabData& data)
 {
-	if (!m_Renderer)
+	if (!data.m_Renderer)
 		return;
 
-	if (m_ImageLock.try_lock())
+	if (data.m_ImageLock.try_lock())
 	{
-		if (m_Renderer->NewResultAvailable())
+		if (data.m_Renderer->NewResultAvailable())
 		{
-			Core::C_Application::Get().GetActiveRenderer().SetTextureData(m_GPUImageHandle, m_ImageStorage);
-			m_Renderer->SetResultConsumed();
+			Core::C_Application::Get().GetActiveRenderer().SetTextureData(data.m_GPUImageHandle, *data.m_ImageStorage);
+			data.m_Renderer->SetResultConsumed();
 		}
-		m_ImageLock.unlock();
+		data.m_ImageLock.unlock();
 	}
 }
 
 //=================================================================================
 void C_MaterialPreviewWindow::Update()
 {
-	if (m_RebuildPending.load())
+	for (auto& tab : m_TabbedView.m_Tabs)
 	{
-		m_RebuildPending.store(false);
-		RebuildAndRestart();
-		return;
+		if (!tab.m_Data)
+			continue;
+		auto& data = *tab.m_Data;
+		if (data.m_RebuildPending.exchange(false))
+			RebuildAndRestart(data);
+		UploadStorage(data);
 	}
-
-	if (!IsVisible() && !m_Running.load())
-	{
-		m_WantToBeDestroyed = true;
-		return;
-	}
-	UploadStorage();
 }
 
 //=================================================================================
 void C_MaterialPreviewWindow::DrawComponents() const
 {
-	if (m_Material.IsReady() && m_Material.GetResource().IsModified())
+	if (!m_TabbedView.HasTabs())
 	{
-		ImGui::Text("Material modified");
+		ImGui::TextUnformatted("No materials open. Use File > New material or double-click a .glmat in the Resource Manager.");
+		return;
 	}
-	std::ignore = m_GUIImage.Draw();
 
+	m_TabbedView.Draw(
+		"##MaterialTabs",
+		[this](S_MaterialTab& tab) { DrawTabContent(tab); },
+		[this](S_MaterialTab& tab) {
+			if (tab.m_Data)
+				const_cast<C_MaterialPreviewWindow*>(this)->SaveMaterial(*tab.m_Data);
+		},
+		[this](S_MaterialTab& tab) { const_cast<C_MaterialPreviewWindow*>(this)->DestroyTabResources(tab); });
+
+	if (m_bCloseRequested)
+	{
+		for (unsigned int i = 0; i < m_TabbedView.m_Tabs.size(); ++i)
+		{
+			auto& tab = m_TabbedView.m_Tabs[i];
+			if (!tab.m_bModified)
+				continue;
+
+			const std::string popupId = std::string("Save changes?##MatClose") + std::to_string(i);
+			if (!ImGui::IsPopupOpen(popupId.c_str()))
+				ImGui::OpenPopup(popupId.c_str());
+
+			if (ImGui::BeginPopupModal(popupId.c_str(), nullptr, ImGuiWindowFlags_AlwaysAutoResize))
+			{
+				ImGui::Text("Save changes to \"%s\"?", tab.m_TabLabel.c_str());
+				ImGui::Separator();
+				if (ImGui::Button("Save", ImVec2(100, 0)))
+				{
+					if (tab.m_Data)
+						const_cast<C_MaterialPreviewWindow*>(this)->SaveMaterial(*tab.m_Data);
+					ImGui::CloseCurrentPopup();
+				}
+				ImGui::SameLine();
+				if (ImGui::Button("Discard", ImVec2(100, 0)))
+				{
+					tab.m_bModified = false;
+					ImGui::CloseCurrentPopup();
+				}
+				ImGui::SameLine();
+				if (ImGui::Button("Cancel", ImVec2(100, 0)))
+				{
+					m_bCloseRequested = false;
+					ImGui::CloseCurrentPopup();
+				}
+				ImGui::EndPopup();
+			}
+			break; // one at a time
+		}
+
+		const bool allClean = std::none_of(m_TabbedView.m_Tabs.begin(), m_TabbedView.m_Tabs.end(), [](const S_MaterialTab& t) { return t.m_bModified; });
+		if (allClean)
+		{
+			m_bCloseRequested = false;
+			const_cast<C_MaterialPreviewWindow*>(this)->GUI::C_Window::OnHide();
+		}
+	}
+}
+
+//=================================================================================
+void C_MaterialPreviewWindow::DrawTabContent(const S_MaterialTab& tab) const
+{
+	auto& data = *tab.m_Data;
 	auto* self = const_cast<C_MaterialPreviewWindow*>(this);
+
+	if (data.m_Material.IsReady() && data.m_Material.GetResource().IsModified())
+		ImGui::Text("Material modified");
+
+	if (data.m_GUIImage)
+		std::ignore = data.m_GUIImage->Draw();
 
 	// Shape selector
 	ImGui::Text("Shape:");
 	ImGui::SameLine();
-	if (ImGui::RadioButton("Sphere", m_PreviewShape == E_PreviewShape::Sphere) && m_PreviewShape != E_PreviewShape::Sphere)
+	if (ImGui::RadioButton("Sphere", data.m_PreviewShape == E_PreviewShape::Sphere) && data.m_PreviewShape != E_PreviewShape::Sphere)
 	{
-		self->m_PreviewShape = E_PreviewShape::Sphere;
-		self->m_RebuildPending.store(true);
+		const_cast<S_MaterialTabData&>(data).m_PreviewShape = E_PreviewShape::Sphere;
+		const_cast<S_MaterialTabData&>(data).m_RebuildPending.store(true);
 	}
 	ImGui::SameLine();
-	if (ImGui::RadioButton("Plane", m_PreviewShape == E_PreviewShape::Plane) && m_PreviewShape != E_PreviewShape::Plane)
+	if (ImGui::RadioButton("Plane", data.m_PreviewShape == E_PreviewShape::Plane) && data.m_PreviewShape != E_PreviewShape::Plane)
 	{
-		self->m_PreviewShape = E_PreviewShape::Plane;
-		self->m_RebuildPending.store(true);
+		const_cast<S_MaterialTabData&>(data).m_PreviewShape = E_PreviewShape::Plane;
+		const_cast<S_MaterialTabData&>(data).m_RebuildPending.store(true);
 	}
 
 	// Render mode selector (GPU disabled until implemented)
@@ -216,107 +313,79 @@ void C_MaterialPreviewWindow::DrawComponents() const
 	ImGui::Separator();
 
 	// Material properties
-	if (m_Material.IsReady())
-		if (self->m_Material.GetResource().DrawGUI())
-			self->RebuildAndRestart();
+	if (data.m_Material.IsReady())
+	{
+		if (const_cast<S_MaterialTabData&>(data).m_Material.GetResource().DrawGUI())
+		{
+			self->RebuildAndRestart(const_cast<S_MaterialTabData&>(data));
+			const_cast<S_MaterialTab&>(tab).m_bModified = true;
+		}
+	}
 
 	ImGui::Separator();
 
 	// Render progress
-	const int samples = m_NumSamples.load();
-	if (m_Running.load())
+	const int samples = data.m_NumSamples.load();
+	if (data.m_Running.load())
 	{
 		ImGui::ProgressBar(static_cast<float>(samples) / s_TargetSamples, ImVec2(-1.f, 0.f));
 		ImGui::Text("Rendering... %d / %d samples", samples, s_TargetSamples);
 	}
 	else
 	{
-		ImGui::Text("Done — %d samples", samples);
+		ImGui::Text("Done \xe2\x80\x94 %d samples", samples);
 		if (ImGui::Button("Re-render"))
-			self->StartRender();
-	}
-
-	if (m_bWaitingForModal)
-	{
-		ImGui::OpenPopup("Confirm##Close");
-		self->m_bWaitingForModal = false;
-	}
-
-	if (ImGui::BeginPopupModal("Confirm##Close", nullptr, ImGuiWindowFlags_AlwaysAutoResize))
-	{
-		ImGui::Text("Material was modified, are you sure you want to close?");
-		ImGui::Separator();
-
-		if (ImGui::Button("Yes", ImVec2(120, 0)))
-		{
-			// TODO should this be just on working copy and not on a live one?
-			self->m_Material.GetResource().Reload();
-			self->m_Material = {};
-			self->SetVisible(false);
-			ImGui::CloseCurrentPopup();
-		}
-		ImGui::SameLine();
-		if (ImGui::Button("Save", ImVec2(120, 0)))
-		{
-			self->m_Material.GetResource().Save();
-			self->m_Material = {};
-			self->SetVisible(false);
-			ImGui::CloseCurrentPopup();
-		}
-
-		ImGui::EndPopup();
+			self->StartRender(const_cast<S_MaterialTabData&>(data));
 	}
 }
 
 //=================================================================================
-void C_MaterialPreviewWindow::RebuildAndRestart()
+void C_MaterialPreviewWindow::RebuildAndRestart(S_MaterialTabData& data)
 {
-	m_StopRequested.store(true);
-	while (m_Running.load())
-		std::this_thread::sleep_for(std::chrono::milliseconds(5));
-	m_StopRequested.store(false);
+	StopTab(data);
+	data.m_StopRequested.store(false);
 
 	constexpr glm::vec4 black{0.f, 0.f, 0.f, 1.f};
-	Renderer::C_TextureView(&m_ImageStorage).ClearColor(black);
-	Renderer::C_TextureView(&m_SamplesStorage).ClearColor(black);
+	Renderer::C_TextureView(&*data.m_ImageStorage).ClearColor(black);
+	Renderer::C_TextureView(&*data.m_SamplesStorage).ClearColor(black);
 
-	SetupScene();
-	StartRender();
+	SetupScene(data);
+	StartRender(data);
+}
+
+//=================================================================================
+void C_MaterialPreviewWindow::StopTab(S_MaterialTabData& data)
+{
+	data.m_StopRequested.store(true);
+	while (data.m_Running.load())
+		std::this_thread::sleep_for(std::chrono::milliseconds(5));
+}
+
+//=================================================================================
+void C_MaterialPreviewWindow::DestroyTabResources(S_MaterialTab& tab)
+{
+	if (!tab.m_Data)
+		return;
+	StopTab(*tab.m_Data);
+	auto& rm = Core::C_Application::Get().GetActiveRenderer().GetRM();
+	if (tab.m_Data->m_GPUImageHandle.IsValid())
+		rm.destoryTexture(tab.m_Data->m_GPUImageHandle);
 }
 
 //=================================================================================
 void C_MaterialPreviewWindow::NewMaterial()
 {
-}
-
-//=================================================================================
-void C_MaterialPreviewWindow::SaveMaterial()
-{
-	if (m_Material.IsReady())
-		m_Material.GetResource().Save();
-}
-
-//=================================================================================
-void C_MaterialPreviewWindow::SaveMaterialAs()
-{
-	if (m_Material.IsReady() == false)
-	{
-		return;
-	}
 	const auto dialogGUID = NextGUID();
 	auto*	   dialog	  = new GUI::C_FileDialogWindow(
 		 ".glmat", "Save material as...",
 		 [this, dialogGUID](const std::filesystem::path& savePath, GUI::C_GUIManager& guiMgr) {
-			 // auto& rm		   = Core::C_ResourceManager::Instance();
-			 // auto  newResource = rm.CreateNewResource<Renderer::MaterialResource>(savePath);
-			 // if (newResource.IsReady())
-			 //{
-			 //	 newResource.GetResource() = m_Material.GetResource();
-			 //}
-			 // m_Material.GetResource().Reload();
-			 // m_Material = newResource;
-			 // m_Material.GetResource().Save();
-
+			 auto& rm		  = Core::C_ResourceManager::Instance();
+			 auto  newResource = rm.CreateNewResource<Renderer::MaterialResource>(savePath);
+			 if (newResource.IsReady())
+			 {
+				 newResource.GetResource().SetMaterialData(std::make_shared<Renderer::C_PBRMaterialData>());
+				 OpenMaterial(std::move(newResource));
+			 }
 			 guiMgr.DestroyWindow(dialogGUID);
 		 },
 		 dialogGUID, Renderer::TextureResource::GetResourceDataPath());
@@ -325,66 +394,84 @@ void C_MaterialPreviewWindow::SaveMaterialAs()
 }
 
 //=================================================================================
-void C_MaterialPreviewWindow::StartRender()
+void C_MaterialPreviewWindow::SaveMaterial(S_MaterialTabData& data)
 {
-	if (m_Running.load())
+	if (!data.m_Material.IsReady())
 		return;
-
-	m_NumSamples.store(0);
-	m_StopRequested.store(false);
-	m_Running.store(true);
-
-	std::thread([this]() {
-		while (!m_StopRequested.load())
-		{
-			const int samplesBefore = m_NumSamples.load();
-			if (samplesBefore >= s_TargetSamples)
-				break;
-
-			m_Renderer->Render(m_Camera, m_ImageStorage, m_SamplesStorage, &m_ImageLock, samplesBefore,
-							   Renderer::C_InterleavedLinesFactory{4});
-			m_NumSamples.fetch_add(1);
-		}
-		m_Running.store(false);
-	}).detach();
+	(void)data.m_Material.GetResource().Save();
+	for (auto& tab : m_TabbedView.m_Tabs)
+		if (tab.m_Data.get() == &data)
+			tab.m_bModified = false;
 }
 
 //=================================================================================
-C_MaterialPreviewWindow::~C_MaterialPreviewWindow()
+void C_MaterialPreviewWindow::SaveMaterialAs(S_MaterialTabData& data)
 {
-	m_StopRequested.store(true);
-	while (m_Running.load())
-		std::this_thread::sleep_for(std::chrono::milliseconds(5));
+	if (!data.m_Material.IsReady())
+		return;
 
-	auto& rm = Core::C_Application::Get().GetActiveRenderer().GetRM();
-	rm.destoryTexture(m_GPUImageHandle);
+	const auto dialogGUID = NextGUID();
+	auto*	   dialog	  = new GUI::C_FileDialogWindow(
+		 ".glmat", "Save material as...",
+		 [&data, dialogGUID](const std::filesystem::path& /*savePath*/, GUI::C_GUIManager& guiMgr) {
+			 // TODO: implement copy-to-new-path
+			 guiMgr.DestroyWindow(dialogGUID);
+		 },
+		 dialogGUID, Renderer::TextureResource::GetResourceDataPath());
+	m_GUIManager.AddCustomWindow(dialog);
+	dialog->SetVisible();
+}
+
+//=================================================================================
+void C_MaterialPreviewWindow::StartRender(S_MaterialTabData& data)
+{
+	if (data.m_Running.load())
+		return;
+
+	data.m_NumSamples.store(0);
+	data.m_StopRequested.store(false);
+	data.m_Running.store(true);
+
+	std::thread([&data, this]() {
+		while (!data.m_StopRequested.load())
+		{
+			const int samplesBefore = data.m_NumSamples.load();
+			if (samplesBefore >= s_TargetSamples)
+				break;
+
+			data.m_Renderer->Render(m_Camera, *data.m_ImageStorage, *data.m_SamplesStorage, &data.m_ImageLock, samplesBefore,
+									Renderer::C_InterleavedLinesFactory{4});
+			data.m_NumSamples.fetch_add(1);
+		}
+		data.m_Running.store(false);
+	}).detach();
 }
 
 //=================================================================================
 void C_MaterialPreviewWindow::RequestDestroy()
 {
-	m_StopRequested.store(true);
+	for (auto& tab : m_TabbedView.m_Tabs)
+		if (tab.m_Data)
+			tab.m_Data->m_StopRequested.store(true);
+	m_WantToBeDestroyed = true;
 }
 
 //=================================================================================
 void C_MaterialPreviewWindow::OnHide()
 {
-	// we postpone hiding, if material was modified
-	if (m_Material.IsReady() && m_Material.GetResource().IsModified())
+	const bool anyModified = std::any_of(m_TabbedView.m_Tabs.begin(), m_TabbedView.m_Tabs.end(), [](const S_MaterialTab& t) { return t.m_bModified; });
+	if (anyModified)
 	{
-		m_bWaitingForModal = true;
-		m_IsVisible		   = true;
+		m_bCloseRequested = true;
+		return;
 	}
-	else
-	{
-		C_Window::OnHide();
-	}
+	GUI::C_Window::OnHide();
 }
 
 //=================================================================================
 bool C_MaterialPreviewWindow::CanDestroy() const
 {
-	return !m_Running.load();
+	return std::none_of(m_TabbedView.m_Tabs.begin(), m_TabbedView.m_Tabs.end(), [](const S_MaterialTab& t) { return t.m_Data && t.m_Data->m_Running.load(); });
 }
 
 } // namespace GLEngine::Editor

--- a/Editor/Editor/Editors/MaterialPreview/MaterialPreviewWindow.h
+++ b/Editor/Editor/Editors/MaterialPreview/MaterialPreviewWindow.h
@@ -1,23 +1,18 @@
 #pragma once
 
 #include <Editor/EditorApi.h>
+#include <Editor/Editors/RayPreviewState.h>
 
 #include <Renderer/Cameras/OrbitalCamera.h>
 #include <Renderer/RayCasting/Geometry/RayTraceScene.h>
-#include <Renderer/RayCasting/RayRenderer.h>
-#include <Renderer/Resources/RenderResourceHandle.h>
-#include <Renderer/Textures/Storage/TextureLinearStorage.h>
 
 #include <GUI/GUIWindow.h>
-#include <GUI/ImageViewer.h>
 #include <GUI/TabbedView.h>
 
 #include <Core/Resources/ResourceHandle.h>
 
 #include <atomic>
 #include <memory>
-#include <mutex>
-#include <optional>
 
 namespace GLEngine::Renderer {
 class MaterialResource;
@@ -36,9 +31,9 @@ public:
 	C_MaterialPreviewWindow(GUID guid, GUI::C_GUIManager& guiMGR);
 	~C_MaterialPreviewWindow() override;
 
-	C_MaterialPreviewWindow(const C_MaterialPreviewWindow&)			= delete;
-	C_MaterialPreviewWindow(C_MaterialPreviewWindow&&) noexcept		= delete;
-	C_MaterialPreviewWindow& operator=(const C_MaterialPreviewWindow&) = delete;
+	C_MaterialPreviewWindow(const C_MaterialPreviewWindow&)				= delete;
+	C_MaterialPreviewWindow(C_MaterialPreviewWindow&&) noexcept			= delete;
+	C_MaterialPreviewWindow& operator=(const C_MaterialPreviewWindow&)	 = delete;
 	C_MaterialPreviewWindow& operator=(C_MaterialPreviewWindow&&) noexcept = delete;
 
 	// Opens the material in a new tab. Switches focus if already open.
@@ -62,42 +57,29 @@ private:
 
 	// Non-moveable per-tab render state, heap-allocated via unique_ptr in S_MaterialTab.
 	struct S_MaterialTabData {
-		Core::ResourceHandle<Renderer::MaterialResource>		m_Material;
-		E_PreviewShape											m_PreviewShape{E_PreviewShape::Sphere};
-		E_RenderMode											m_RenderMode{E_RenderMode::CPU};
-		std::atomic<bool>										m_RebuildPending{false};
+		Core::ResourceHandle<Renderer::MaterialResource> m_Material;
+		E_PreviewShape									 m_PreviewShape{E_PreviewShape::Sphere};
+		E_RenderMode									 m_RenderMode{E_RenderMode::CPU};
+		std::atomic<bool>								 m_RebuildPending{false};
 
-		Renderer::C_RayTraceScene							m_Scene;
-		std::unique_ptr<Renderer::C_RayRenderer>			m_Renderer;
-
-		Renderer::Handle<Renderer::Texture>						  m_GPUImageHandle;
-		std::optional<Renderer::C_TextureViewStorageCPU<float>>   m_ImageStorage;
-		std::optional<Renderer::C_TextureViewStorageCPU<float>>   m_SamplesStorage;
-		std::optional<GUI::C_ImageViewer>						  m_GUIImage;
-
-		std::mutex		  m_ImageLock;
-		std::atomic<int>  m_NumSamples{0};
-		std::atomic<bool> m_Running{false};
-		std::atomic<bool> m_StopRequested{false};
+		Renderer::C_RayTraceScene m_Scene;
+		S_RayPreviewState		  m_Render; // GPU handle, storage, image viewer, render thread state
 	};
 
 	// Satisfies TabbedViewTab. Moveable because S_MaterialTabData is behind a unique_ptr.
 	struct S_MaterialTab {
-		std::string							   m_TabLabel;
-		bool								   m_bModified = false;
-		std::unique_ptr<S_MaterialTabData>	   m_Data;
+		std::string							  m_TabLabel;
+		bool								  m_bModified = false;
+		std::unique_ptr<S_MaterialTabData>	  m_Data;
 	};
 
 	void DrawComponents() const override;
 	void DrawTabContent(const S_MaterialTab& tab) const;
 
-	void CreateTabResources(S_MaterialTabData& data);
 	void SetupScene(S_MaterialTabData& data);
 	void SetupCamera();
 	void StartRender(S_MaterialTabData& data);
-	void UploadStorage(S_MaterialTabData& data);
 	void RebuildAndRestart(S_MaterialTabData& data);
-	void StopTab(S_MaterialTabData& data);
 	void DestroyTabResources(S_MaterialTab& tab);
 
 	void NewMaterial();
@@ -105,7 +87,6 @@ private:
 	void SaveMaterialAs(S_MaterialTabData& data);
 
 	mutable GUI::C_TabbedView<S_MaterialTab> m_TabbedView;
-	mutable bool							 m_bCloseRequested = false;
 
 	Renderer::Cameras::C_OrbitalCamera m_Camera; // shared — fixed viewpoint, same for all tabs
 	GUI::Menu::C_Menu				   m_FileMenu;

--- a/Editor/Editor/Editors/MaterialPreview/MaterialPreviewWindow.h
+++ b/Editor/Editor/Editors/MaterialPreview/MaterialPreviewWindow.h
@@ -10,11 +10,14 @@
 
 #include <GUI/GUIWindow.h>
 #include <GUI/ImageViewer.h>
+#include <GUI/TabbedView.h>
 
 #include <Core/Resources/ResourceHandle.h>
 
 #include <atomic>
+#include <memory>
 #include <mutex>
+#include <optional>
 
 namespace GLEngine::Renderer {
 class MaterialResource;
@@ -30,13 +33,16 @@ enum class E_PreviewShape
 
 class EDITOR_API_EXPORT C_MaterialPreviewWindow final : public GUI::C_Window {
 public:
-	C_MaterialPreviewWindow(GUID guid, GUI::C_GUIManager& guiMGR, Core::ResourceHandle<Renderer::MaterialResource> material);
+	C_MaterialPreviewWindow(GUID guid, GUI::C_GUIManager& guiMGR);
 	~C_MaterialPreviewWindow() override;
 
-	C_MaterialPreviewWindow(const C_MaterialPreviewWindow& other)		= delete;
-	C_MaterialPreviewWindow(C_MaterialPreviewWindow&& other) noexcept	= delete;
-	C_MaterialPreviewWindow& operator=(const C_MaterialPreviewWindow& other) = delete;
-	C_MaterialPreviewWindow& operator=(C_MaterialPreviewWindow&& other) noexcept = delete;
+	C_MaterialPreviewWindow(const C_MaterialPreviewWindow&)			= delete;
+	C_MaterialPreviewWindow(C_MaterialPreviewWindow&&) noexcept		= delete;
+	C_MaterialPreviewWindow& operator=(const C_MaterialPreviewWindow&) = delete;
+	C_MaterialPreviewWindow& operator=(C_MaterialPreviewWindow&&) noexcept = delete;
+
+	// Opens the material in a new tab. Switches focus if already open.
+	void OpenMaterial(Core::ResourceHandle<Renderer::MaterialResource> handle);
 
 	void			   RequestDestroy() override;
 	[[nodiscard]] bool CanDestroy() const override;
@@ -44,48 +50,66 @@ public:
 	void			   OnHide() override;
 
 private:
-	void DrawComponents() const override;
-	void SetupScene();
-	void SetupCamera();
-	void StartRender();
-	void UploadStorage();
-	void RebuildAndRestart();
+	static constexpr int		s_TargetSamples = 128;
+	static constexpr glm::uvec2 s_Resolution{512, 512};
 
-	void NewMaterial();
-	void SaveMaterial();
-	void SaveMaterialAs();
-
-	Core::ResourceHandle<Renderer::MaterialResource> m_Material;
-	E_PreviewShape									 m_PreviewShape{E_PreviewShape::Sphere};
-	std::atomic<bool>								 m_RebuildPending{false};
-
-	Renderer::C_RayTraceScene				   m_Scene;
-	Renderer::Cameras::C_OrbitalCamera		   m_Camera;
-	std::unique_ptr<Renderer::C_RayRenderer>   m_Renderer;
-
-	Renderer::Handle<Renderer::Texture>		 m_GPUImageHandle;
-	Renderer::C_TextureViewStorageCPU<float> m_ImageStorage;
-	Renderer::C_TextureViewStorageCPU<float> m_SamplesStorage;
-	GUI::C_ImageViewer						 m_GUIImage;
-	GUI::Menu::C_Menu						 m_FileMenu;
-	GUI::C_GUIManager&						 m_GUIManager;
-
-	std::mutex		  m_ImageLock;
-	std::atomic<int>  m_NumSamples{0};
-	std::atomic<bool> m_Running{false};
-	std::atomic<bool> m_StopRequested{false};
-	bool			  m_bWaitingForModal{false};
-
-	// GPU rasterizer placeholder — extend this enum when GPU path is implemented
+	// GPU rasterizer placeholder — extend when GPU path is implemented
 	enum class E_RenderMode
 	{
 		CPU,
 		// GPU,
 	};
-	E_RenderMode m_RenderMode{E_RenderMode::CPU};
 
-	static constexpr int		s_TargetSamples = 128;
-	static constexpr glm::uvec2 s_Resolution{512, 512};
+	// Non-moveable per-tab render state, heap-allocated via unique_ptr in S_MaterialTab.
+	struct S_MaterialTabData {
+		Core::ResourceHandle<Renderer::MaterialResource>		m_Material;
+		E_PreviewShape											m_PreviewShape{E_PreviewShape::Sphere};
+		E_RenderMode											m_RenderMode{E_RenderMode::CPU};
+		std::atomic<bool>										m_RebuildPending{false};
+
+		Renderer::C_RayTraceScene							m_Scene;
+		std::unique_ptr<Renderer::C_RayRenderer>			m_Renderer;
+
+		Renderer::Handle<Renderer::Texture>						  m_GPUImageHandle;
+		std::optional<Renderer::C_TextureViewStorageCPU<float>>   m_ImageStorage;
+		std::optional<Renderer::C_TextureViewStorageCPU<float>>   m_SamplesStorage;
+		std::optional<GUI::C_ImageViewer>						  m_GUIImage;
+
+		std::mutex		  m_ImageLock;
+		std::atomic<int>  m_NumSamples{0};
+		std::atomic<bool> m_Running{false};
+		std::atomic<bool> m_StopRequested{false};
+	};
+
+	// Satisfies TabbedViewTab. Moveable because S_MaterialTabData is behind a unique_ptr.
+	struct S_MaterialTab {
+		std::string							   m_TabLabel;
+		bool								   m_bModified = false;
+		std::unique_ptr<S_MaterialTabData>	   m_Data;
+	};
+
+	void DrawComponents() const override;
+	void DrawTabContent(const S_MaterialTab& tab) const;
+
+	void CreateTabResources(S_MaterialTabData& data);
+	void SetupScene(S_MaterialTabData& data);
+	void SetupCamera();
+	void StartRender(S_MaterialTabData& data);
+	void UploadStorage(S_MaterialTabData& data);
+	void RebuildAndRestart(S_MaterialTabData& data);
+	void StopTab(S_MaterialTabData& data);
+	void DestroyTabResources(S_MaterialTab& tab);
+
+	void NewMaterial();
+	void SaveMaterial(S_MaterialTabData& data);
+	void SaveMaterialAs(S_MaterialTabData& data);
+
+	mutable GUI::C_TabbedView<S_MaterialTab> m_TabbedView;
+	mutable bool							 m_bCloseRequested = false;
+
+	Renderer::Cameras::C_OrbitalCamera m_Camera; // shared — fixed viewpoint, same for all tabs
+	GUI::Menu::C_Menu				   m_FileMenu;
+	GUI::C_GUIManager&				   m_GUIManager;
 };
 
 } // namespace GLEngine::Editor

--- a/Editor/Editor/Editors/RayPreviewState.cpp
+++ b/Editor/Editor/Editors/RayPreviewState.cpp
@@ -1,0 +1,106 @@
+#include <EditorStdafx.h>
+
+#include <Editor/Editors/RayPreviewState.h>
+
+#include <imgui.h>
+
+#include <GUI/ImageViewer.h>
+
+#include <Renderer/IRenderer.h>
+#include <Renderer/Textures/TextureView.h>
+#include <Renderer/Resources/ResourceManager.h>
+
+#include <Core/Application.h>
+
+#include <chrono>
+#include <thread>
+
+namespace GLEngine::Editor {
+
+//=================================================================================
+void CreateRayPreviewState(S_RayPreviewState& state,
+						   glm::uvec2		  resolution,
+						   std::string_view	  name,
+						   Renderer::E_TextureFormat format)
+{
+	auto& renderer = Core::C_Application::Get().GetActiveRenderer();
+
+	state.m_GPUImageHandle = renderer.GetRM().createTexture(Renderer::TextureDescriptor{
+		.name		   = std::string(name),
+		.width		   = resolution.x,
+		.height		   = resolution.y,
+		.type		   = Renderer::E_TextureType::TEXTURE_2D,
+		.format		   = format,
+		.m_bStreamable = false,
+	});
+	const auto samplerHandle = renderer.GetRM().createSampler(Renderer::SamplerDescriptor2D{
+		.m_FilterMin = Renderer::E_TextureFilter::Linear,
+		.m_FilterMag = Renderer::E_TextureFilter::Linear,
+		.m_WrapS	 = Renderer::E_WrapFunction::Repeat,
+		.m_WrapT	 = Renderer::E_WrapFunction::Repeat,
+		.m_WrapU	 = Renderer::E_WrapFunction::Repeat,
+	});
+	renderer.SetTextureSampler(state.m_GPUImageHandle, samplerHandle);
+
+	state.m_ImageStorage.emplace(resolution.x, resolution.y, 3);
+	state.m_SamplesStorage.emplace(resolution.x, resolution.y, 3);
+
+	constexpr glm::vec4 black{0.f, 0.f, 0.f, 1.f};
+	Renderer::C_TextureView(&*state.m_ImageStorage).ClearColor(black);
+	Renderer::C_TextureView(&*state.m_SamplesStorage).ClearColor(black);
+	renderer.SetTextureData(state.m_GPUImageHandle, *state.m_ImageStorage);
+
+	state.m_GUIImage = std::make_unique<GUI::C_ImageViewer>(state.m_GPUImageHandle);
+	state.m_GUIImage->SetSize({resolution.x, resolution.y});
+}
+
+//=================================================================================
+void StopPreviewRender(S_RayPreviewState& state)
+{
+	state.m_StopRequested.store(true);
+	while (state.m_Running.load())
+		std::this_thread::sleep_for(std::chrono::milliseconds(5));
+}
+
+//=================================================================================
+void DestroyRayPreviewState(S_RayPreviewState& state)
+{
+	StopPreviewRender(state);
+	auto& rm = Core::C_Application::Get().GetActiveRenderer().GetRM();
+	if (state.m_GPUImageHandle.IsValid())
+		rm.destoryTexture(state.m_GPUImageHandle);
+}
+
+//=================================================================================
+void UploadPreviewStorage(S_RayPreviewState& state)
+{
+	if (!state.m_Renderer)
+		return;
+
+	if (state.m_ImageLock.try_lock())
+	{
+		if (state.m_Renderer->NewResultAvailable())
+		{
+			Core::C_Application::Get().GetActiveRenderer()
+				.SetTextureData(state.m_GPUImageHandle, *state.m_ImageStorage);
+			state.m_Renderer->SetResultConsumed();
+		}
+		state.m_ImageLock.unlock();
+	}
+}
+
+//=================================================================================
+bool DrawRenderProgress(const S_RayPreviewState& state, int targetSamples)
+{
+	const int samples = state.m_NumSamples.load();
+	if (state.m_Running.load())
+	{
+		ImGui::ProgressBar(static_cast<float>(samples) / targetSamples, ImVec2(-1.f, 0.f));
+		ImGui::Text("Rendering... %d / %d samples", samples, targetSamples);
+		return false;
+	}
+	ImGui::Text("Done - %d samples", samples);
+	return ImGui::Button("Re-render");
+}
+
+} // namespace GLEngine::Editor

--- a/Editor/Editor/Editors/RayPreviewState.h
+++ b/Editor/Editor/Editors/RayPreviewState.h
@@ -1,0 +1,74 @@
+#pragma once
+
+#include <Editor/EditorApi.h>
+
+#include <Renderer/RayCasting/RayRenderer.h>
+#include <Renderer/Resources/RenderResourceHandle.h>
+#include <Renderer/Textures/Storage/TextureLinearStorage.h>
+
+#include <glm/glm.hpp>
+
+#include <atomic>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <string_view>
+
+// Forward declarations — ImageViewer.h requires imgui.h; include it only in .cpp files
+namespace GLEngine::GUI {
+class C_ImageViewer;
+} // namespace GLEngine::GUI
+
+namespace GLEngine::Renderer {
+enum class E_TextureFormat : std::uint8_t;
+} // namespace GLEngine::Renderer
+
+namespace GLEngine::Editor {
+
+/**
+ * Shared render-thread state embedded in per-tab data for ray-tracing preview
+ * editors (MaterialPreviewWindow, TrimeshPreviewWindow).
+ *
+ * Non-copyable and non-moveable (contains atomic and mutex members).
+ * Always heap-allocate via unique_ptr inside the tab struct.
+ */
+struct S_RayPreviewState {
+	Renderer::Handle<Renderer::Texture>						  m_GPUImageHandle;
+	std::optional<Renderer::C_TextureViewStorageCPU<float>>   m_ImageStorage;
+	std::optional<Renderer::C_TextureViewStorageCPU<float>>   m_SamplesStorage;
+	std::unique_ptr<GUI::C_ImageViewer>						  m_GUIImage;
+	std::unique_ptr<Renderer::C_RayRenderer>				  m_Renderer;
+
+	std::mutex		  m_ImageLock;
+	std::atomic<int>  m_NumSamples{0};
+	std::atomic<bool> m_Running{false};
+	std::atomic<bool> m_StopRequested{false};
+
+	S_RayPreviewState()								= default;
+	S_RayPreviewState(const S_RayPreviewState&)		= delete;
+	S_RayPreviewState(S_RayPreviewState&&) noexcept = delete;
+	S_RayPreviewState& operator=(const S_RayPreviewState&)		= delete;
+	S_RayPreviewState& operator=(S_RayPreviewState&&) noexcept	= delete;
+};
+
+// Allocates GPU texture + sampler, initialises image/samples storage, clears to black,
+// uploads initial black frame, and creates the C_ImageViewer.
+EDITOR_API_EXPORT void CreateRayPreviewState(S_RayPreviewState& state,
+											 glm::uvec2			resolution,
+											 std::string_view	name,
+											 Renderer::E_TextureFormat format);
+
+// Sets m_StopRequested, busy-waits until m_Running is false, then destroys the GPU texture.
+EDITOR_API_EXPORT void DestroyRayPreviewState(S_RayPreviewState& state);
+
+// Sets m_StopRequested and busy-waits until m_Running is false.
+EDITOR_API_EXPORT void StopPreviewRender(S_RayPreviewState& state);
+
+// try_lock + upload to GPU if the renderer has a new result pending.
+EDITOR_API_EXPORT void UploadPreviewStorage(S_RayPreviewState& state);
+
+// Draws ProgressBar + status text, or "Done" + Re-render button.
+// Returns true when the Re-render button is clicked.
+EDITOR_API_EXPORT bool DrawRenderProgress(const S_RayPreviewState& state, int targetSamples);
+
+} // namespace GLEngine::Editor

--- a/Editor/Editor/Editors/ResourceManager/ResourceManagerWindow.cpp
+++ b/Editor/Editor/Editors/ResourceManager/ResourceManagerWindow.cpp
@@ -338,17 +338,23 @@ void C_ResourceManagerWindow::OnResourceDoubleClicked(const std::filesystem::pat
 	// --- Material → Material Preview ---
 	if (resMgr.IsResourceType<Renderer::MaterialResource>(path))
 	{
-		if (m_GUIManager.GetWindow(m_MaterialPreviewGUID) != nullptr)
-			return;
-
 		auto handle = resMgr.LoadResource<Renderer::MaterialResource>(path, /*isBlocking=*/true);
 		if (!handle.IsReady())
 			return;
 
-		m_MaterialPreviewGUID = NextGUID();
-		auto* preview		  = new C_MaterialPreviewWindow(m_MaterialPreviewGUID, m_GUIManager, std::move(handle));
-		m_GUIManager.AddCustomWindow(preview);
-		preview->SetVisible(true);
+		if (auto* win = static_cast<C_MaterialPreviewWindow*>(m_GUIManager.GetWindow(m_MaterialPreviewGUID)))
+		{
+			win->OpenMaterial(std::move(handle));
+			win->SetVisible(true);
+		}
+		else
+		{
+			m_MaterialPreviewGUID = NextGUID();
+			auto* preview		  = new C_MaterialPreviewWindow(m_MaterialPreviewGUID, m_GUIManager);
+			preview->OpenMaterial(std::move(handle));
+			m_GUIManager.AddCustomWindow(preview);
+			preview->SetVisible(true);
+		}
 	}
 }
 

--- a/Editor/Editor/Editors/ResourceManager/ResourceManagerWindow.cpp
+++ b/Editor/Editor/Editors/ResourceManager/ResourceManagerWindow.cpp
@@ -320,18 +320,23 @@ void C_ResourceManagerWindow::OnResourceDoubleClicked(const std::filesystem::pat
 	// --- Trimesh → Trimesh Preview ---
 	if (resMgr.IsResourceType<Renderer::C_TrimeshModel>(path))
 	{
-		// Don't reopen if already showing this model
-		if (m_GUIManager.GetWindow(m_TrimeshPreviewGUID) != nullptr)
-			return;
-
 		auto handle = resMgr.LoadResource<Renderer::C_TrimeshModel>(path, /*isBlocking=*/true);
 		if (!handle.IsReady())
 			return;
 
-		m_TrimeshPreviewGUID = NextGUID();
-		auto* preview		 = new C_TrimeshPreviewWindow(m_TrimeshPreviewGUID, m_GUIManager, std::move(handle));
-		m_GUIManager.AddCustomWindow(preview);
-		preview->SetVisible(true);
+		if (auto* win = static_cast<C_TrimeshPreviewWindow*>(m_GUIManager.GetWindow(m_TrimeshPreviewGUID)))
+		{
+			win->OpenModel(std::move(handle));
+			win->SetVisible(true);
+		}
+		else
+		{
+			m_TrimeshPreviewGUID = NextGUID();
+			auto* preview		 = new C_TrimeshPreviewWindow(m_TrimeshPreviewGUID, m_GUIManager);
+			preview->OpenModel(std::move(handle));
+			m_GUIManager.AddCustomWindow(preview);
+			preview->SetVisible(true);
+		}
 		return;
 	}
 

--- a/Editor/Editor/Editors/TrimeshPreview/TrimeshPreviewWindow.cpp
+++ b/Editor/Editor/Editors/TrimeshPreview/TrimeshPreviewWindow.cpp
@@ -27,23 +27,49 @@
 namespace GLEngine::Editor {
 
 //=================================================================================
-C_TrimeshPreviewWindow::C_TrimeshPreviewWindow(GUID guid,
-											   GUI::C_GUIManager&                              guiMGR,
-											   Core::ResourceHandle<Renderer::C_TrimeshModel> model)
+C_TrimeshPreviewWindow::C_TrimeshPreviewWindow(GUID guid, GUI::C_GUIManager& guiMGR)
 	: GUI::C_Window(guid, "Trimesh Preview")
-	, m_Model(std::move(model))
-	, m_ImageStorage(s_Resolution.x, s_Resolution.y, 3)
-	, m_SamplesStorage(s_Resolution.x, s_Resolution.y, 3)
-	, m_GUIImage({})
+	, m_GUIManager(guiMGR)
+{
+}
+
+//=================================================================================
+C_TrimeshPreviewWindow::~C_TrimeshPreviewWindow()
+{
+	for (auto& tab : m_TabbedView.m_Tabs)
+		if (tab.m_Data)
+			DestroyTabResources(tab);
+}
+
+//=================================================================================
+void C_TrimeshPreviewWindow::OpenModel(Core::ResourceHandle<Renderer::C_TrimeshModel> handle)
+{
+	const auto path = handle.GetFilePath();
+	if (m_TabbedView.TrySwitchTo([&](const S_TrimeshTab& t) {
+			return t.m_Data && t.m_Data->m_Model.GetFilePath() == path;
+		}))
+		return;
+
+	auto& tab	 = m_TabbedView.EmplaceTab();
+	tab.m_Data	 = std::make_unique<S_TrimeshTabData>();
+	tab.m_Data->m_Model = std::move(handle);
+	tab.m_TabLabel		= tab.m_Data->m_Model.GetFilePath().filename().string();
+	CreateTabResources(*tab.m_Data);
+	SetupScene(*tab.m_Data); // calls SetupCamera internally
+	StartRender(*tab.m_Data);
+}
+
+//=================================================================================
+void C_TrimeshPreviewWindow::CreateTabResources(S_TrimeshTabData& data)
 {
 	auto& renderer = Core::C_Application::Get().GetActiveRenderer();
 
-	m_GPUImageHandle = renderer.GetRM().createTexture(Renderer::TextureDescriptor{
-		.name		  = "trimeshPreview",
-		.width		  = s_Resolution.x,
-		.height		  = s_Resolution.y,
-		.type		  = Renderer::E_TextureType::TEXTURE_2D,
-		.format		  = Renderer::E_TextureFormat::RGB32f,
+	data.m_GPUImageHandle = renderer.GetRM().createTexture(Renderer::TextureDescriptor{
+		.name		   = "trimeshPreview",
+		.width		   = s_Resolution.x,
+		.height		   = s_Resolution.y,
+		.type		   = Renderer::E_TextureType::TEXTURE_2D,
+		.format		   = Renderer::E_TextureFormat::RGB32f,
 		.m_bStreamable = false,
 	});
 	const auto samplerHandle = renderer.GetRM().createSampler(Renderer::SamplerDescriptor2D{
@@ -53,36 +79,35 @@ C_TrimeshPreviewWindow::C_TrimeshPreviewWindow(GUID guid,
 		.m_WrapT	 = Renderer::E_WrapFunction::Repeat,
 		.m_WrapU	 = Renderer::E_WrapFunction::Repeat,
 	});
-	renderer.SetTextureSampler(m_GPUImageHandle, samplerHandle);
+	renderer.SetTextureSampler(data.m_GPUImageHandle, samplerHandle);
 
-	m_GUIImage = GUI::C_ImageViewer(m_GPUImageHandle);
-	m_GUIImage.SetSize({s_Resolution.x, s_Resolution.y});
+	data.m_ImageStorage.emplace(s_Resolution.x, s_Resolution.y, 3);
+	data.m_SamplesStorage.emplace(s_Resolution.x, s_Resolution.y, 3);
 
 	constexpr glm::vec4 black{0.f, 0.f, 0.f, 1.f};
-	Renderer::C_TextureView(&m_ImageStorage).ClearColor(black);
-	Renderer::C_TextureView(&m_SamplesStorage).ClearColor(black);
-	renderer.SetTextureData(m_GPUImageHandle, m_ImageStorage);
+	Renderer::C_TextureView(&*data.m_ImageStorage).ClearColor(black);
+	Renderer::C_TextureView(&*data.m_SamplesStorage).ClearColor(black);
+	renderer.SetTextureData(data.m_GPUImageHandle, *data.m_ImageStorage);
 
-	SetupScene();
-	StartRender();
+	data.m_GUIImage.emplace(data.m_GPUImageHandle);
+	data.m_GUIImage->SetSize({s_Resolution.x, s_Resolution.y});
 }
 
 //=================================================================================
-void C_TrimeshPreviewWindow::SetupScene()
+void C_TrimeshPreviewWindow::SetupScene(S_TrimeshTabData& data)
 {
-	m_Scene.ClearScene();
+	data.m_Scene.ClearScene();
 
 	Physics::Primitives::S_AABB combinedAABB;
-	for (const auto& trimesh : m_Model.GetResource().GetTrimeshes())
+	for (const auto& trimesh : data.m_Model.GetResource().GetTrimeshes())
 		combinedAABB.Add(trimesh.GetAABB());
 
-	m_Scene.AddMesh(m_Model); // identity transform (default from Task 1)
+	data.m_Scene.AddMesh(data.m_Model);
 
-	const auto    sphere = combinedAABB.GetSphere();
-	const float   r      = sphere.m_radius;
-	const glm::vec3 c    = sphere.m_position;
+	const auto	  sphere = combinedAABB.GetSphere();
+	const float	  r		 = sphere.m_radius;
+	const glm::vec3 c	 = sphere.m_position;
 
-	// One overhead disc area light centred above the mesh
 	static const Renderer::MeshData::Material s_Black{.ambient			  = glm::vec4{},
 													  .diffuse			  = glm::vec4{Colours::black, 0.f},
 													  .specular			  = glm::vec4{},
@@ -94,135 +119,164 @@ void C_TrimeshPreviewWindow::SetupScene()
 	const glm::vec3 lightNormal = glm::normalize(glm::vec3(0.f, -1.f, 0.f));
 	auto disc = Physics::Primitives::S_Disc(lightNormal, c + glm::vec3(0.f, r * 3.f, 0.f), r * 1.5f);
 	disc.plane.twoSided = false;
-	auto discPrimitive  = std::make_shared<Renderer::C_Primitive<Physics::Primitives::S_Disc>>(disc);
-	discPrimitive->SetMaterial(m_Scene.AddMaterial(s_Black).get());
-	m_Scene.AddLight(std::make_shared<Renderer::RayTracing::C_AreaLight>(
+	auto discPrimitive	= std::make_shared<Renderer::C_Primitive<Physics::Primitives::S_Disc>>(disc);
+	discPrimitive->SetMaterial(data.m_Scene.AddMaterial(s_Black).get());
+	data.m_Scene.AddLight(std::make_shared<Renderer::RayTracing::C_AreaLight>(
 		glm::vec3(1.f, 1.f, 1.f) * 5.f, discPrimitive));
 
-	SetupCamera(combinedAABB);
+	SetupCamera(data);
 
-	m_Renderer = std::make_unique<Renderer::C_RayRenderer>(m_Scene);
+	data.m_Renderer = std::make_unique<Renderer::C_RayRenderer>(data.m_Scene);
 }
 
 //=================================================================================
-void C_TrimeshPreviewWindow::SetupCamera(const Physics::Primitives::S_AABB& combinedAABB)
+void C_TrimeshPreviewWindow::SetupCamera(S_TrimeshTabData& data)
 {
-	const auto    sphere   = combinedAABB.GetSphere();
-	const float   r        = sphere.m_radius > 0.f ? sphere.m_radius : 1.f;
+	Physics::Primitives::S_AABB combinedAABB;
+	for (const auto& trimesh : data.m_Model.GetResource().GetTrimeshes())
+		combinedAABB.Add(trimesh.GetAABB());
+
+	const auto	  sphere   = combinedAABB.GetSphere();
+	const float	  r		   = sphere.m_radius > 0.f ? sphere.m_radius : 1.f;
 	const glm::vec3 center = sphere.m_position;
 
 	const float distance = r * 3.f;
+	const float nearZ	 = std::max(0.01f, distance - r);
+	const float farZ	 = distance + r;
+	const float fovY	 = glm::degrees(2.f * std::atan((r * 1.1f) / distance));
 
-	const float nearZ = std::max(0.01f, distance - r);
-	const float farZ  = distance + r;
-	const float fovY  = glm::degrees(2.f * std::atan((r * 1.1f) / distance));
-
-	// Top-right view: 45° azimuth, 35° elevation
-	m_Camera.SetupCameraView(distance, center, 45.f, 35.f);
-	m_Camera.SetupCameraProjection(nearZ, farZ, 1.f /*square aspect*/, fovY);
-	m_Camera.Update();
+	data.m_Camera.SetupCameraView(distance, center, 45.f, 35.f);
+	data.m_Camera.SetupCameraProjection(nearZ, farZ, 1.f, fovY);
+	data.m_Camera.Update();
 }
 
 //=================================================================================
-void C_TrimeshPreviewWindow::UploadStorage()
+void C_TrimeshPreviewWindow::StartRender(S_TrimeshTabData& data)
 {
-	if (!m_Renderer)
+	if (data.m_Running.load())
 		return;
 
-	if (m_ImageLock.try_lock())
+	data.m_NumSamples.store(0);
+	data.m_StopRequested.store(false);
+	data.m_Running.store(true);
+
+	std::thread([&data]() {
+		while (!data.m_StopRequested.load())
+		{
+			const int samplesBefore = data.m_NumSamples.load();
+			if (samplesBefore >= s_TargetSamples)
+				break;
+
+			data.m_Renderer->Render(data.m_Camera,
+									*data.m_ImageStorage,
+									*data.m_SamplesStorage,
+									&data.m_ImageLock,
+									samplesBefore,
+									Renderer::C_InterleavedLinesFactory{4});
+			data.m_NumSamples.fetch_add(1);
+		}
+		data.m_Running.store(false);
+	}).detach();
+}
+
+//=================================================================================
+void C_TrimeshPreviewWindow::UploadStorage(S_TrimeshTabData& data)
+{
+	if (!data.m_Renderer)
+		return;
+
+	if (data.m_ImageLock.try_lock())
 	{
-		if (m_Renderer->NewResultAvailable())
+		if (data.m_Renderer->NewResultAvailable())
 		{
 			Core::C_Application::Get().GetActiveRenderer()
-				.SetTextureData(m_GPUImageHandle, m_ImageStorage);
-			m_Renderer->SetResultConsumed();
+				.SetTextureData(data.m_GPUImageHandle, *data.m_ImageStorage);
+			data.m_Renderer->SetResultConsumed();
 		}
-		m_ImageLock.unlock();
+		data.m_ImageLock.unlock();
 	}
+}
+
+//=================================================================================
+void C_TrimeshPreviewWindow::StopTab(S_TrimeshTabData& data)
+{
+	data.m_StopRequested.store(true);
+	while (data.m_Running.load())
+		std::this_thread::sleep_for(std::chrono::milliseconds(5));
+}
+
+//=================================================================================
+void C_TrimeshPreviewWindow::DestroyTabResources(S_TrimeshTab& tab)
+{
+	if (!tab.m_Data)
+		return;
+	StopTab(*tab.m_Data);
+	auto& rm = Core::C_Application::Get().GetActiveRenderer().GetRM();
+	rm.destoryTexture(tab.m_Data->m_GPUImageHandle);
 }
 
 //=================================================================================
 void C_TrimeshPreviewWindow::Update()
 {
-	if (!IsVisible() && !m_Running.load())
-	{
-		m_WantToBeDestroyed = true;
-		return;
-	}
-	UploadStorage();
+	for (auto& tab : m_TabbedView.m_Tabs)
+		if (tab.m_Data)
+			UploadStorage(*tab.m_Data);
 }
 
 //=================================================================================
 void C_TrimeshPreviewWindow::DrawComponents() const
 {
-	std::ignore = m_GUIImage.Draw();
-
-	const int samples = m_NumSamples.load();
-	if (m_Running.load())
+	if (!m_TabbedView.HasTabs())
 	{
-		ImGui::ProgressBar(static_cast<float>(samples) / s_TargetSamples,
-						   ImVec2(-1.f, 0.f));
+		ImGui::TextDisabled("No model open. Double-click a .tri file in the Resource Manager.");
+		return;
+	}
+
+	m_TabbedView.Draw(
+		"##TrimeshTabs",
+		[this](const S_TrimeshTab& tab) { DrawTabContent(tab); },
+		[this](S_TrimeshTab& tab) { const_cast<C_TrimeshPreviewWindow*>(this)->DestroyTabResources(tab); });
+}
+
+//=================================================================================
+void C_TrimeshPreviewWindow::DrawTabContent(const S_TrimeshTab& tab) const
+{
+	if (!tab.m_Data)
+		return;
+
+	const S_TrimeshTabData& data = *tab.m_Data;
+
+	if (data.m_GUIImage)
+		std::ignore = data.m_GUIImage->Draw();
+
+	const int samples = data.m_NumSamples.load();
+	if (data.m_Running.load())
+	{
+		ImGui::ProgressBar(static_cast<float>(samples) / s_TargetSamples, ImVec2(-1.f, 0.f));
 		ImGui::Text("Rendering... %d / %d samples", samples, s_TargetSamples);
 	}
 	else
 	{
 		ImGui::Text("Done — %d samples", samples);
 		if (ImGui::Button("Re-render"))
-			const_cast<C_TrimeshPreviewWindow*>(this)->StartRender();
+			const_cast<C_TrimeshPreviewWindow*>(this)->StartRender(*tab.m_Data);
 	}
-}
-
-//=================================================================================
-void C_TrimeshPreviewWindow::StartRender()
-{
-	if (m_Running.load())
-		return;
-
-	m_NumSamples.store(0);
-	m_StopRequested.store(false);
-	m_Running.store(true);
-
-	std::thread([this]() {
-		while (!m_StopRequested.load())
-		{
-			const int samplesBefore = m_NumSamples.load();
-			if (samplesBefore >= s_TargetSamples)
-				break;
-
-			m_Renderer->Render(m_Camera,
-							   m_ImageStorage,
-							   m_SamplesStorage,
-							   &m_ImageLock,
-							   samplesBefore,
-							   Renderer::C_InterleavedLinesFactory{4});
-			m_NumSamples.fetch_add(1);
-		}
-		m_Running.store(false);
-	}).detach();
-}
-
-//=================================================================================
-C_TrimeshPreviewWindow::~C_TrimeshPreviewWindow()
-{
-	m_StopRequested.store(true);
-	while (m_Running.load())
-		std::this_thread::sleep_for(std::chrono::milliseconds(5));
-
-	auto& rm = Core::C_Application::Get().GetActiveRenderer().GetRM();
-	rm.destoryTexture(m_GPUImageHandle);
 }
 
 //=================================================================================
 void C_TrimeshPreviewWindow::RequestDestroy()
 {
-	GUI::C_Window::RequestDestroy();
-	m_StopRequested.store(true);
+	for (auto& tab : m_TabbedView.m_Tabs)
+		if (tab.m_Data)
+			tab.m_Data->m_StopRequested.store(true);
+	m_WantToBeDestroyed = true;
 }
 
 //=================================================================================
 bool C_TrimeshPreviewWindow::CanDestroy() const
 {
-	return !m_Running.load();
+	return std::none_of(m_TabbedView.m_Tabs.begin(), m_TabbedView.m_Tabs.end(),
+						[](const S_TrimeshTab& t) { return t.m_Data && t.m_Data->m_Running.load(); });
 }
 
 } // namespace GLEngine::Editor

--- a/Editor/Editor/Editors/TrimeshPreview/TrimeshPreviewWindow.cpp
+++ b/Editor/Editor/Editors/TrimeshPreview/TrimeshPreviewWindow.cpp
@@ -160,6 +160,8 @@ void C_TrimeshPreviewWindow::DestroyTabResources(S_TrimeshTab& tab)
 //=================================================================================
 void C_TrimeshPreviewWindow::Update()
 {
+	if (m_WantToBeDestroyed)
+		return;
 	for (auto& tab : m_TabbedView.m_Tabs)
 		if (tab.m_Data)
 			UploadPreviewStorage(tab.m_Data->m_Render);

--- a/Editor/Editor/Editors/TrimeshPreview/TrimeshPreviewWindow.cpp
+++ b/Editor/Editor/Editors/TrimeshPreview/TrimeshPreviewWindow.cpp
@@ -1,6 +1,9 @@
 #include <EditorStdafx.h>
 
 #include <Editor/Editors/TrimeshPreview/TrimeshPreviewWindow.h>
+#include <Editor/Editors/RayPreviewState.h>
+
+#include <GUI/ImageViewer.h>
 
 #include <Renderer/IDevice.h>
 #include <Renderer/IRenderer.h>
@@ -10,7 +13,6 @@
 #include <Renderer/RayCasting/Light/RayAreaLight.h>
 #include <Renderer/Mesh/Scene.h>
 #include <Renderer/Colours.h>
-#include <Renderer/Textures/TextureView.h>
 #include <Renderer/Resources/ResourceManager.h>
 
 #include <Physics/Primitives/AABB.h>
@@ -54,43 +56,11 @@ void C_TrimeshPreviewWindow::OpenModel(Core::ResourceHandle<Renderer::C_TrimeshM
 	tab.m_Data	 = std::make_unique<S_TrimeshTabData>();
 	tab.m_Data->m_Model = std::move(handle);
 	tab.m_TabLabel		= tab.m_Data->m_Model.GetFilePath().filename().string();
-	CreateTabResources(*tab.m_Data);
-	SetupScene(*tab.m_Data); // calls SetupCamera internally
+
+	CreateRayPreviewState(tab.m_Data->m_Render, s_Resolution, "trimeshPreview",
+						  Renderer::E_TextureFormat::RGB32f);
+	SetupScene(*tab.m_Data);
 	StartRender(*tab.m_Data);
-}
-
-//=================================================================================
-void C_TrimeshPreviewWindow::CreateTabResources(S_TrimeshTabData& data)
-{
-	auto& renderer = Core::C_Application::Get().GetActiveRenderer();
-
-	data.m_GPUImageHandle = renderer.GetRM().createTexture(Renderer::TextureDescriptor{
-		.name		   = "trimeshPreview",
-		.width		   = s_Resolution.x,
-		.height		   = s_Resolution.y,
-		.type		   = Renderer::E_TextureType::TEXTURE_2D,
-		.format		   = Renderer::E_TextureFormat::RGB32f,
-		.m_bStreamable = false,
-	});
-	const auto samplerHandle = renderer.GetRM().createSampler(Renderer::SamplerDescriptor2D{
-		.m_FilterMin = Renderer::E_TextureFilter::Linear,
-		.m_FilterMag = Renderer::E_TextureFilter::Linear,
-		.m_WrapS	 = Renderer::E_WrapFunction::Repeat,
-		.m_WrapT	 = Renderer::E_WrapFunction::Repeat,
-		.m_WrapU	 = Renderer::E_WrapFunction::Repeat,
-	});
-	renderer.SetTextureSampler(data.m_GPUImageHandle, samplerHandle);
-
-	data.m_ImageStorage.emplace(s_Resolution.x, s_Resolution.y, 3);
-	data.m_SamplesStorage.emplace(s_Resolution.x, s_Resolution.y, 3);
-
-	constexpr glm::vec4 black{0.f, 0.f, 0.f, 1.f};
-	Renderer::C_TextureView(&*data.m_ImageStorage).ClearColor(black);
-	Renderer::C_TextureView(&*data.m_SamplesStorage).ClearColor(black);
-	renderer.SetTextureData(data.m_GPUImageHandle, *data.m_ImageStorage);
-
-	data.m_GUIImage.emplace(data.m_GPUImageHandle);
-	data.m_GUIImage->SetSize({s_Resolution.x, s_Resolution.y});
 }
 
 //=================================================================================
@@ -126,7 +96,7 @@ void C_TrimeshPreviewWindow::SetupScene(S_TrimeshTabData& data)
 
 	SetupCamera(data);
 
-	data.m_Renderer = std::make_unique<Renderer::C_RayRenderer>(data.m_Scene);
+	data.m_Render.m_Renderer = std::make_unique<Renderer::C_RayRenderer>(data.m_Scene);
 }
 
 //=================================================================================
@@ -153,56 +123,30 @@ void C_TrimeshPreviewWindow::SetupCamera(S_TrimeshTabData& data)
 //=================================================================================
 void C_TrimeshPreviewWindow::StartRender(S_TrimeshTabData& data)
 {
-	if (data.m_Running.load())
+	if (data.m_Render.m_Running.load())
 		return;
 
-	data.m_NumSamples.store(0);
-	data.m_StopRequested.store(false);
-	data.m_Running.store(true);
+	data.m_Render.m_NumSamples.store(0);
+	data.m_Render.m_StopRequested.store(false);
+	data.m_Render.m_Running.store(true);
 
 	std::thread([&data]() {
-		while (!data.m_StopRequested.load())
+		while (!data.m_Render.m_StopRequested.load())
 		{
-			const int samplesBefore = data.m_NumSamples.load();
+			const int samplesBefore = data.m_Render.m_NumSamples.load();
 			if (samplesBefore >= s_TargetSamples)
 				break;
 
-			data.m_Renderer->Render(data.m_Camera,
-									*data.m_ImageStorage,
-									*data.m_SamplesStorage,
-									&data.m_ImageLock,
-									samplesBefore,
-									Renderer::C_InterleavedLinesFactory{4});
-			data.m_NumSamples.fetch_add(1);
+			data.m_Render.m_Renderer->Render(data.m_Camera,
+											 *data.m_Render.m_ImageStorage,
+											 *data.m_Render.m_SamplesStorage,
+											 &data.m_Render.m_ImageLock,
+											 samplesBefore,
+											 Renderer::C_InterleavedLinesFactory{4});
+			data.m_Render.m_NumSamples.fetch_add(1);
 		}
-		data.m_Running.store(false);
+		data.m_Render.m_Running.store(false);
 	}).detach();
-}
-
-//=================================================================================
-void C_TrimeshPreviewWindow::UploadStorage(S_TrimeshTabData& data)
-{
-	if (!data.m_Renderer)
-		return;
-
-	if (data.m_ImageLock.try_lock())
-	{
-		if (data.m_Renderer->NewResultAvailable())
-		{
-			Core::C_Application::Get().GetActiveRenderer()
-				.SetTextureData(data.m_GPUImageHandle, *data.m_ImageStorage);
-			data.m_Renderer->SetResultConsumed();
-		}
-		data.m_ImageLock.unlock();
-	}
-}
-
-//=================================================================================
-void C_TrimeshPreviewWindow::StopTab(S_TrimeshTabData& data)
-{
-	data.m_StopRequested.store(true);
-	while (data.m_Running.load())
-		std::this_thread::sleep_for(std::chrono::milliseconds(5));
 }
 
 //=================================================================================
@@ -210,9 +154,7 @@ void C_TrimeshPreviewWindow::DestroyTabResources(S_TrimeshTab& tab)
 {
 	if (!tab.m_Data)
 		return;
-	StopTab(*tab.m_Data);
-	auto& rm = Core::C_Application::Get().GetActiveRenderer().GetRM();
-	rm.destoryTexture(tab.m_Data->m_GPUImageHandle);
+	DestroyRayPreviewState(tab.m_Data->m_Render);
 }
 
 //=================================================================================
@@ -220,7 +162,7 @@ void C_TrimeshPreviewWindow::Update()
 {
 	for (auto& tab : m_TabbedView.m_Tabs)
 		if (tab.m_Data)
-			UploadStorage(*tab.m_Data);
+			UploadPreviewStorage(tab.m_Data->m_Render);
 }
 
 //=================================================================================
@@ -246,21 +188,11 @@ void C_TrimeshPreviewWindow::DrawTabContent(const S_TrimeshTab& tab) const
 
 	const S_TrimeshTabData& data = *tab.m_Data;
 
-	if (data.m_GUIImage)
-		std::ignore = data.m_GUIImage->Draw();
+	if (data.m_Render.m_GUIImage)
+		std::ignore = data.m_Render.m_GUIImage->Draw();
 
-	const int samples = data.m_NumSamples.load();
-	if (data.m_Running.load())
-	{
-		ImGui::ProgressBar(static_cast<float>(samples) / s_TargetSamples, ImVec2(-1.f, 0.f));
-		ImGui::Text("Rendering... %d / %d samples", samples, s_TargetSamples);
-	}
-	else
-	{
-		ImGui::Text("Done — %d samples", samples);
-		if (ImGui::Button("Re-render"))
-			const_cast<C_TrimeshPreviewWindow*>(this)->StartRender(*tab.m_Data);
-	}
+	if (DrawRenderProgress(data.m_Render, s_TargetSamples))
+		const_cast<C_TrimeshPreviewWindow*>(this)->StartRender(*tab.m_Data);
 }
 
 //=================================================================================
@@ -268,7 +200,7 @@ void C_TrimeshPreviewWindow::RequestDestroy()
 {
 	for (auto& tab : m_TabbedView.m_Tabs)
 		if (tab.m_Data)
-			tab.m_Data->m_StopRequested.store(true);
+			tab.m_Data->m_Render.m_StopRequested.store(true);
 	m_WantToBeDestroyed = true;
 }
 
@@ -276,7 +208,7 @@ void C_TrimeshPreviewWindow::RequestDestroy()
 bool C_TrimeshPreviewWindow::CanDestroy() const
 {
 	return std::none_of(m_TabbedView.m_Tabs.begin(), m_TabbedView.m_Tabs.end(),
-						[](const S_TrimeshTab& t) { return t.m_Data && t.m_Data->m_Running.load(); });
+						[](const S_TrimeshTab& t) { return t.m_Data && t.m_Data->m_Render.m_Running.load(); });
 }
 
 } // namespace GLEngine::Editor

--- a/Editor/Editor/Editors/TrimeshPreview/TrimeshPreviewWindow.h
+++ b/Editor/Editor/Editors/TrimeshPreview/TrimeshPreviewWindow.h
@@ -1,23 +1,18 @@
 #pragma once
 
 #include <Editor/EditorApi.h>
+#include <Editor/Editors/RayPreviewState.h>
 
 #include <Renderer/Cameras/OrbitalCamera.h>
 #include <Renderer/RayCasting/Geometry/RayTraceScene.h>
-#include <Renderer/RayCasting/RayRenderer.h>
-#include <Renderer/Resources/RenderResourceHandle.h>
-#include <Renderer/Textures/Storage/TextureLinearStorage.h>
 
 #include <GUI/GUIWindow.h>
-#include <GUI/ImageViewer.h>
 #include <GUI/TabbedView.h>
 
 #include <Core/Resources/ResourceHandle.h>
 
 #include <atomic>
 #include <memory>
-#include <mutex>
-#include <optional>
 
 namespace GLEngine::Renderer {
 class C_TrimeshModel;
@@ -50,19 +45,9 @@ private:
 	struct S_TrimeshTabData {
 		Core::ResourceHandle<Renderer::C_TrimeshModel> m_Model;
 
-		Renderer::C_RayTraceScene					 m_Scene;
-		Renderer::Cameras::C_OrbitalCamera			 m_Camera; // PER-TAB — geometry-dependent
-		std::unique_ptr<Renderer::C_RayRenderer>	 m_Renderer;
-
-		Renderer::Handle<Renderer::Texture>						  m_GPUImageHandle;
-		std::optional<Renderer::C_TextureViewStorageCPU<float>>   m_ImageStorage;
-		std::optional<Renderer::C_TextureViewStorageCPU<float>>   m_SamplesStorage;
-		std::optional<GUI::C_ImageViewer>						  m_GUIImage;
-
-		std::mutex		  m_ImageLock;
-		std::atomic<int>  m_NumSamples{0};
-		std::atomic<bool> m_Running{false};
-		std::atomic<bool> m_StopRequested{false};
+		Renderer::C_RayTraceScene		   m_Scene;
+		Renderer::Cameras::C_OrbitalCamera m_Camera; // PER-TAB — geometry-dependent
+		S_RayPreviewState				   m_Render;  // GPU handle, storage, image viewer, render thread state
 	};
 
 	// Satisfies TabbedViewTab. Moveable because S_TrimeshTabData is behind a unique_ptr.
@@ -75,12 +60,9 @@ private:
 	void DrawComponents() const override;
 	void DrawTabContent(const S_TrimeshTab& tab) const;
 
-	void CreateTabResources(S_TrimeshTabData& data);
 	void SetupScene(S_TrimeshTabData& data);
 	void SetupCamera(S_TrimeshTabData& data);
 	void StartRender(S_TrimeshTabData& data);
-	void UploadStorage(S_TrimeshTabData& data);
-	void StopTab(S_TrimeshTabData& data);
 	void DestroyTabResources(S_TrimeshTab& tab);
 
 	mutable GUI::C_TabbedView<S_TrimeshTab> m_TabbedView;

--- a/Editor/Editor/Editors/TrimeshPreview/TrimeshPreviewWindow.h
+++ b/Editor/Editor/Editors/TrimeshPreview/TrimeshPreviewWindow.h
@@ -10,11 +10,14 @@
 
 #include <GUI/GUIWindow.h>
 #include <GUI/ImageViewer.h>
+#include <GUI/TabbedView.h>
 
 #include <Core/Resources/ResourceHandle.h>
 
 #include <atomic>
+#include <memory>
 #include <mutex>
+#include <optional>
 
 namespace GLEngine::Renderer {
 class C_TrimeshModel;
@@ -24,42 +27,64 @@ namespace GLEngine::Editor {
 
 class EDITOR_API_EXPORT C_TrimeshPreviewWindow final : public GUI::C_Window {
 public:
-	C_TrimeshPreviewWindow(GUID guid, GUI::C_GUIManager& guiMGR, Core::ResourceHandle<Renderer::C_TrimeshModel> model);
+	C_TrimeshPreviewWindow(GUID guid, GUI::C_GUIManager& guiMGR);
 	~C_TrimeshPreviewWindow() override;
 
-	C_TrimeshPreviewWindow(const C_TrimeshPreviewWindow& other)		= delete;
-	C_TrimeshPreviewWindow(C_TrimeshPreviewWindow&& other) noexcept = delete;
-	C_TrimeshPreviewWindow& operator=(const C_TrimeshPreviewWindow& other) = delete;
-	C_TrimeshPreviewWindow& operator=(C_TrimeshPreviewWindow&& other) noexcept = delete;
+	C_TrimeshPreviewWindow(const C_TrimeshPreviewWindow&)			= delete;
+	C_TrimeshPreviewWindow(C_TrimeshPreviewWindow&&) noexcept		= delete;
+	C_TrimeshPreviewWindow& operator=(const C_TrimeshPreviewWindow&) = delete;
+	C_TrimeshPreviewWindow& operator=(C_TrimeshPreviewWindow&&) noexcept = delete;
+
+	// Opens the model in a new tab. Switches focus if already open.
+	void OpenModel(Core::ResourceHandle<Renderer::C_TrimeshModel> handle);
 
 	void			   RequestDestroy() override;
 	[[nodiscard]] bool CanDestroy() const override;
 	void			   Update() override;
 
 private:
-	void DrawComponents() const override;
-	void SetupScene();
-	void SetupCamera(const Physics::Primitives::S_AABB& combinedAABB);
-	void StartRender();
-	void UploadStorage();
-
-	Core::ResourceHandle<Renderer::C_TrimeshModel> m_Model;
-	Renderer::C_RayTraceScene					   m_Scene;
-	Renderer::Cameras::C_OrbitalCamera			   m_Camera;
-	std::unique_ptr<Renderer::C_RayRenderer>	   m_Renderer;
-
-	Renderer::Handle<Renderer::Texture>		 m_GPUImageHandle;
-	Renderer::C_TextureViewStorageCPU<float> m_ImageStorage;
-	Renderer::C_TextureViewStorageCPU<float> m_SamplesStorage;
-	GUI::C_ImageViewer						 m_GUIImage;
-
-	std::mutex		  m_ImageLock;
-	std::atomic<int>  m_NumSamples{0};
-	std::atomic<bool> m_Running{false};
-	std::atomic<bool> m_StopRequested{false};
-
 	static constexpr int		s_TargetSamples = 128;
 	static constexpr glm::uvec2 s_Resolution{512, 512};
+
+	// Non-moveable per-tab render state, heap-allocated via unique_ptr in S_TrimeshTab.
+	struct S_TrimeshTabData {
+		Core::ResourceHandle<Renderer::C_TrimeshModel> m_Model;
+
+		Renderer::C_RayTraceScene					 m_Scene;
+		Renderer::Cameras::C_OrbitalCamera			 m_Camera; // PER-TAB — geometry-dependent
+		std::unique_ptr<Renderer::C_RayRenderer>	 m_Renderer;
+
+		Renderer::Handle<Renderer::Texture>						  m_GPUImageHandle;
+		std::optional<Renderer::C_TextureViewStorageCPU<float>>   m_ImageStorage;
+		std::optional<Renderer::C_TextureViewStorageCPU<float>>   m_SamplesStorage;
+		std::optional<GUI::C_ImageViewer>						  m_GUIImage;
+
+		std::mutex		  m_ImageLock;
+		std::atomic<int>  m_NumSamples{0};
+		std::atomic<bool> m_Running{false};
+		std::atomic<bool> m_StopRequested{false};
+	};
+
+	// Satisfies TabbedViewTab. Moveable because S_TrimeshTabData is behind a unique_ptr.
+	struct S_TrimeshTab {
+		std::string							  m_TabLabel;
+		bool								  m_bModified = false; // always false — read-only
+		std::unique_ptr<S_TrimeshTabData>	  m_Data;
+	};
+
+	void DrawComponents() const override;
+	void DrawTabContent(const S_TrimeshTab& tab) const;
+
+	void CreateTabResources(S_TrimeshTabData& data);
+	void SetupScene(S_TrimeshTabData& data);
+	void SetupCamera(S_TrimeshTabData& data);
+	void StartRender(S_TrimeshTabData& data);
+	void UploadStorage(S_TrimeshTabData& data);
+	void StopTab(S_TrimeshTabData& data);
+	void DestroyTabResources(S_TrimeshTab& tab);
+
+	mutable GUI::C_TabbedView<S_TrimeshTab> m_TabbedView;
+	GUI::C_GUIManager&						m_GUIManager;
 };
 
 } // namespace GLEngine::Editor

--- a/GUI/GUI/FileDialogWindow.cpp
+++ b/GUI/GUI/FileDialogWindow.cpp
@@ -62,12 +62,14 @@ void C_FileDialogWindow::SetBasePath(const std::filesystem::path& basePath)
 void C_FileDialogWindow::OnSetVisible()
 {
 	ImGuiFileDialog::Instance()->OpenDialog(m_WindowName, m_WindowTitle, m_FileType.c_str(), m_BasePath.generic_string(), "");
+	m_IsVisible = true;
 }
 
 //=================================================================================
 void C_FileDialogWindow::OnHide()
 {
 	ImGuiFileDialog::Instance()->Close();
+	m_IsVisible = false;
 }
 
 } // namespace GLEngine::GUI

--- a/GUI/GUI/TabbedView.h
+++ b/GUI/GUI/TabbedView.h
@@ -2,6 +2,7 @@
 
 #include <imgui.h>
 
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -24,9 +25,8 @@ concept TabbedViewTab = requires(T t) {
 template <TabbedViewTab TabT>
 class C_TabbedView {
 public:
-	// Renders the tab bar.
-	// drawContent(TabT&) — called for the active tab's body.
-	// onClose(TabT&)     — called before a closed tab is erased (use for resource cleanup).
+	// Renders the tab bar without save confirmation.
+	// onClose(TabT&) — called before a closed tab is erased regardless of m_bModified.
 	template <typename DrawFn, typename CloseFn>
 	void Draw(std::string_view barId, DrawFn&& drawContent, CloseFn&& onClose, ImGuiTabBarFlags flags = ImGuiTabBarFlags_AutoSelectNewTabs) const
 	{
@@ -48,13 +48,85 @@ public:
 				if (!open)
 				{
 					onClose(tab);
-					m_Tabs.erase(m_Tabs.begin() + i);
-					if (m_ActiveTabIndex >= m_Tabs.size())
-						m_ActiveTabIndex = static_cast<unsigned int>(m_Tabs.size()) > 0 ? static_cast<unsigned int>(m_Tabs.size()) - 1 : 0;
+					EraseTab(i);
 					--i;
 				}
 			}
 			ImGui::EndTabBar();
+		}
+	}
+
+	// Renders the tab bar with save confirmation for modified tabs.
+	// onSave(TabT&)    — called when user clicks Save; tab is closed only if m_bModified becomes false.
+	// onDiscard(TabT&) — called for resource cleanup when user clicks Discard or tab is unmodified.
+	template <typename DrawFn, typename SaveFn, typename DiscardFn>
+	void Draw(std::string_view barId, DrawFn&& drawContent, SaveFn&& onSave, DiscardFn&& onDiscard, ImGuiTabBarFlags flags = ImGuiTabBarFlags_AutoSelectNewTabs) const
+	{
+		if (ImGui::BeginTabBar(barId.data(), flags))
+		{
+			for (unsigned int i = 0; i < m_Tabs.size(); ++i)
+			{
+				auto&			  tab	= m_Tabs[i];
+				const std::string label = tab.m_TabLabel + (tab.m_bModified ? " *" : "") + "##tab" + std::to_string(i);
+				bool			  open	= true;
+
+				if (ImGui::BeginTabItem(label.c_str(), &open))
+				{
+					m_ActiveTabIndex = i;
+					drawContent(tab);
+					ImGui::EndTabItem();
+				}
+
+				if (!open && !m_PendingCloseIndex)
+				{
+					if (tab.m_bModified)
+					{
+						m_PendingCloseIndex = i;
+						ImGui::OpenPopup("Save changes?##TabClose");
+					}
+					else
+					{
+						onDiscard(tab);
+						EraseTab(i);
+						--i;
+					}
+				}
+			}
+			ImGui::EndTabBar();
+		}
+
+		if (m_PendingCloseIndex)
+		{
+			if (ImGui::BeginPopupModal("Save changes?##TabClose", nullptr, ImGuiWindowFlags_AlwaysAutoResize))
+			{
+				auto& pendingTab = m_Tabs[*m_PendingCloseIndex];
+				ImGui::Text("Save changes to \"%s\"?", pendingTab.m_TabLabel.c_str());
+				ImGui::Separator();
+
+				if (ImGui::Button("Save", ImVec2(100, 0)))
+				{
+					onSave(pendingTab);
+					if (!pendingTab.m_bModified)
+						EraseTab(*m_PendingCloseIndex);
+					m_PendingCloseIndex.reset();
+					ImGui::CloseCurrentPopup();
+				}
+				ImGui::SameLine();
+				if (ImGui::Button("Discard", ImVec2(100, 0)))
+				{
+					onDiscard(pendingTab);
+					EraseTab(*m_PendingCloseIndex);
+					m_PendingCloseIndex.reset();
+					ImGui::CloseCurrentPopup();
+				}
+				ImGui::SameLine();
+				if (ImGui::Button("Cancel", ImVec2(100, 0)))
+				{
+					m_PendingCloseIndex.reset();
+					ImGui::CloseCurrentPopup();
+				}
+				ImGui::EndPopup();
+			}
 		}
 	}
 
@@ -86,9 +158,17 @@ public:
 		return false;
 	}
 
-	mutable std::vector<TabT> m_Tabs;
+	mutable std::vector<TabT>			 m_Tabs;
+	mutable std::optional<unsigned int>  m_PendingCloseIndex;
 
 private:
+	void EraseTab(unsigned int i) const
+	{
+		m_Tabs.erase(m_Tabs.begin() + i);
+		if (m_ActiveTabIndex >= m_Tabs.size() && !m_Tabs.empty())
+			m_ActiveTabIndex = static_cast<unsigned int>(m_Tabs.size()) - 1;
+	}
+
 	mutable unsigned int m_ActiveTabIndex = 0;
 };
 

--- a/GUI/GUI/TabbedView.h
+++ b/GUI/GUI/TabbedView.h
@@ -1,0 +1,95 @@
+#pragma once
+
+#include <imgui.h>
+
+#include <string>
+#include <vector>
+
+namespace GLEngine::GUI {
+
+template <typename T>
+concept TabbedViewTab = requires(T t) {
+	{ t.m_TabLabel } -> std::convertible_to<std::string>;
+	{ t.m_bModified } -> std::convertible_to<bool>;
+};
+
+/**
+ * Composable tab-bar component. Owns a vector of tabs and handles all ImGui
+ * tab-bar rendering, active-tab tracking, and close-button lifecycle.
+ *
+ * TabT must expose:
+ *   std::string m_TabLabel
+ *   bool        m_bModified
+ */
+template <TabbedViewTab TabT>
+class C_TabbedView {
+public:
+	// Renders the tab bar.
+	// drawContent(TabT&) — called for the active tab's body.
+	// onClose(TabT&)     — called before a closed tab is erased (use for resource cleanup).
+	template <typename DrawFn, typename CloseFn>
+	void Draw(std::string_view barId, DrawFn&& drawContent, CloseFn&& onClose, ImGuiTabBarFlags flags = ImGuiTabBarFlags_AutoSelectNewTabs) const
+	{
+		if (ImGui::BeginTabBar(barId.data(), flags))
+		{
+			for (unsigned int i = 0; i < m_Tabs.size(); ++i)
+			{
+				auto&			  tab	= m_Tabs[i];
+				const std::string label = tab.m_TabLabel + (tab.m_bModified ? " *" : "") + "##tab" + std::to_string(i);
+				bool			  open	= true;
+
+				if (ImGui::BeginTabItem(label.c_str(), &open))
+				{
+					m_ActiveTabIndex = i;
+					drawContent(tab);
+					ImGui::EndTabItem();
+				}
+
+				if (!open)
+				{
+					onClose(tab);
+					m_Tabs.erase(m_Tabs.begin() + i);
+					if (m_ActiveTabIndex >= m_Tabs.size())
+						m_ActiveTabIndex = static_cast<unsigned int>(m_Tabs.size()) > 0 ? static_cast<unsigned int>(m_Tabs.size()) - 1 : 0;
+					--i;
+				}
+			}
+			ImGui::EndTabBar();
+		}
+	}
+
+	[[nodiscard]] bool HasTabs() const { return !m_Tabs.empty(); }
+
+	TabT&		ActiveTab() { return m_Tabs[m_ActiveTabIndex]; }
+	const TabT& ActiveTab() const { return m_Tabs[m_ActiveTabIndex]; }
+
+	// Constructs a new tab in-place and returns a reference to it.
+	// Note: invalidates all existing references (vector may reallocate).
+	template <typename... Args>
+	TabT& EmplaceTab(Args&&... args)
+	{
+		return m_Tabs.emplace_back(std::forward<Args>(args)...);
+	}
+
+	// Switches to the first tab satisfying pred. Returns true if found.
+	template <typename Pred>
+	bool TrySwitchTo(Pred&& pred)
+	{
+		for (unsigned int i = 0; i < m_Tabs.size(); ++i)
+		{
+			if (pred(m_Tabs[i]))
+			{
+				m_ActiveTabIndex = i;
+				return true;
+			}
+		}
+		return false;
+	}
+
+	mutable std::vector<TabT> m_Tabs;
+
+private:
+	mutable unsigned int m_ActiveTabIndex = 0;
+};
+
+} // namespace GLEngine::GUI

--- a/GUI/GUI/TabbedView.h
+++ b/GUI/GUI/TabbedView.h
@@ -132,6 +132,67 @@ public:
 
 	[[nodiscard]] bool HasTabs() const { return !m_Tabs.empty(); }
 
+	// --- Editor-close workflow ---
+	// Call from OnHide() when any modified tab should block the window closing.
+	void RequestEditorClose() const { m_bEditorCloseRequested = true; }
+	[[nodiscard]] bool IsEditorCloseRequested() const { return m_bEditorCloseRequested; }
+
+	// Draws sequential Save/Discard/Cancel popups, one per modified tab.
+	// Call from DrawComponents() each frame while close is requested.
+	// saveFn(TabT&)   — called on Save; should set tab.m_bModified = false on success
+	// onAllClean()    — called once all tabs are unmodified (e.g. GUI::C_Window::OnHide())
+	// popupPrefix     — unique ImGui ID suffix (e.g. "##ImageClose") to avoid popup ID collisions
+	template <typename SaveFn, typename CleanFn>
+	void DrawEditorCloseModals(std::string_view popupPrefix, SaveFn&& saveFn, CleanFn&& onAllClean) const
+	{
+		if (!m_bEditorCloseRequested)
+			return;
+
+		for (unsigned int i = 0; i < m_Tabs.size(); ++i)
+		{
+			auto& tab = m_Tabs[i];
+			if (!tab.m_bModified)
+				continue;
+
+			const std::string popupId = std::string("Save changes?") + popupPrefix.data() + std::to_string(i);
+			if (!ImGui::IsPopupOpen(popupId.c_str()))
+				ImGui::OpenPopup(popupId.c_str());
+
+			if (ImGui::BeginPopupModal(popupId.c_str(), nullptr, ImGuiWindowFlags_AlwaysAutoResize))
+			{
+				ImGui::Text("Save changes to \"%s\"?", tab.m_TabLabel.c_str());
+				ImGui::Separator();
+				if (ImGui::Button("Save", ImVec2(100, 0)))
+				{
+					saveFn(tab);
+					ImGui::CloseCurrentPopup();
+				}
+				ImGui::SameLine();
+				if (ImGui::Button("Discard", ImVec2(100, 0)))
+				{
+					tab.m_bModified = false;
+					ImGui::CloseCurrentPopup();
+				}
+				ImGui::SameLine();
+				if (ImGui::Button("Cancel", ImVec2(100, 0)))
+				{
+					m_bEditorCloseRequested = false;
+					ImGui::CloseCurrentPopup();
+				}
+				ImGui::EndPopup();
+			}
+			break; // one popup at a time
+		}
+
+		const bool allClean = std::none_of(m_Tabs.begin(), m_Tabs.end(),
+			[](const TabT& t) { return t.m_bModified; });
+		if (allClean)
+		{
+			m_bEditorCloseRequested = false;
+			onAllClean();
+		}
+	}
+
 	TabT&		ActiveTab() { return m_Tabs[m_ActiveTabIndex]; }
 	const TabT& ActiveTab() const { return m_Tabs[m_ActiveTabIndex]; }
 
@@ -169,7 +230,8 @@ private:
 			m_ActiveTabIndex = static_cast<unsigned int>(m_Tabs.size()) - 1;
 	}
 
-	mutable unsigned int m_ActiveTabIndex = 0;
+	mutable unsigned int m_ActiveTabIndex		= 0;
+	mutable bool		 m_bEditorCloseRequested = false;
 };
 
 } // namespace GLEngine::GUI


### PR DESCRIPTION
# Describe the contribution

Added a unified way for resource editors to use tabs with close guards, new resource, save resource etc.
## Fixed issues
- 

## Informations

**Checklist**
- [ ] Changelist included
- [ ] Tests for fixed bugs
- [ ] Clang-format

**Test Configuration**:
* GPU:
* Backend:
* OS: 

**Affected backends**
- [ ] CPU
- [ ] OpenGL
- [ ] Vulkan
- [ ] DirectX